### PR TITLE
Fix make manifests to not include webhook

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN go mod download
 COPY pkg/main.go pkg/main.go
 COPY api/ api/
 COPY pkg/controllers/ pkg/controllers/
-COPY vendor vendor
+#COPY vendor vendor                     # Developer Note: Needs to be retreived for every build
 COPY Makefile Makefile
 COPY hack hack
 

--- a/Makefile
+++ b/Makefile
@@ -43,8 +43,8 @@ help: ## Display this help.
 ##@ Development
 
 .PHONY: manifests
-manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects. rm -f config/crd/*.yaml
-	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd
+manifests: controller-gen ## Generate ClusterRole and CustomResourceDefinition objects. rm -f config/crd/*.yaml
+	$(CONTROLLER_GEN) rbac:roleName=hypershfit-deployment-controller crd paths="./..." output:crd:artifacts:config=config/crd
 
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.


### PR DESCRIPTION
related details. Remove vendor from Dockerfile COPY

Signed-off-by: Joshua Packer <jpacker@redhat.com>

* Remove webhook from `make manifests`
* Remove `vendor` from Dockerfile