### PR TITLE
Add Provider Secret Condition

### DIFF
--- a/api/v1alpha1/hypershiftdeployment_types.go
+++ b/api/v1alpha1/hypershiftdeployment_types.go
@@ -35,11 +35,15 @@ const (
 	PlatformIAMConfiguredAsExpected = "PlatformIAMConfiguredAsExpected"
 	PlatformIAMRemove               = "PlatformIAMRemove"
 	PlatformIAMMisConfiguredReason  = "PlatformIAMMisconfigured"
+	ProviderSecretFoundAsExpected   = "ProviderSecretReferenceAsExpected"
+	ProviderSecretRefMisConfigured  = "ProviderSecretReferenceMisConfigured"
 
 	// PlatformConfigured indicates (if status is true) that the
-	// platform configuration specified for the platform provider has been deployed
-	PlatformConfigured    ConditionType = "PlatformInfrastructureConfigured"
-	PlatformIAMConfigured ConditionType = "PlatformIAMConfigured"
+	// platform configuration specified for the platform provider has been applied
+	PlatformConfigured ConditionType = "PlatformInfrastructureConfigured"
+	// PlatformIAMConfigured indicates (if status is true) that the IAM is configured
+	PlatformIAMConfigured    ConditionType = "PlatformIAMConfigured"
+	ProviderSecretConfigured ConditionType = "ProviderSecretConfigured"
 
 	PhaseInfrastructure = "Infrastructure"
 	PhaseHostedCluster  = "HostedCluster"
@@ -126,10 +130,12 @@ type HypershiftDeploymentStatus struct {
 // +kubebuilder:resource:path=hypershiftdeployments,shortName=hd;hds,scope=Namespaced
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
-// +kubebuilder:printcolumn:name="Reason",type="string",JSONPath=".status.conditions[?(@.type==\"PlatformInfrastructureConfigured\")].reason",description="Reason"
-// +kubebuilder:printcolumn:name="IAM Ready",type="string",JSONPath=".status.conditions[?(@.type==\"PlatformIAMConfigured\")].status",description="Configured"
-// +kubebuilder:printcolumn:name="Reason",type="string",JSONPath=".status.conditions[?(@.type==\"PlatformIAMConfigured\")].reason",description="Reason"
-// +kubebuilder:printcolumn:name="INFRA Ready",type="string",JSONPath=".status.conditions[?(@.type==\"PlatformInfrastructureConfigured\")].status",description="Configured"
+// +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.conditions[?(@.type==\"PlatformInfrastructureConfigured\")].reason",description="Reason"
+// +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type==\"PlatformIAMConfigured\")].status",description="Configured"
+// +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.conditions[?(@.type==\"PlatformIAMConfigured\")].reason",description="Reason"
+// +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type==\"PlatformInfrastructureConfigured\")].status",description="Configured"
+// +kubebuilder:printcolumn:name="Reference",type="string",JSONPath=".status.conditions[?(@.type==\"ProviderSecretConfigured\")].reason",description="Reason"
+// +kubebuilder:printcolumn:name="Found",type="string",JSONPath=".status.conditions[?(@.type==\"ProviderSecretConfigured\")].status",description="Found"
 
 // HypershiftDeployment is the Schema for the hypershiftDeployments API
 type HypershiftDeployment struct {

--- a/config/crd/cluster.open-cluster-management.io_hypershiftdeployments.yaml
+++ b/config/crd/cluster.open-cluster-management.io_hypershiftdeployments.yaml
@@ -22,19 +22,27 @@ spec:
   - additionalPrinterColumns:
     - description: Reason
       jsonPath: .status.conditions[?(@.type=="PlatformInfrastructureConfigured")].reason
-      name: Reason
+      name: Status
       type: string
     - description: Configured
       jsonPath: .status.conditions[?(@.type=="PlatformIAMConfigured")].status
-      name: IAM Ready
+      name: Ready
       type: string
     - description: Reason
       jsonPath: .status.conditions[?(@.type=="PlatformIAMConfigured")].reason
-      name: Reason
+      name: Status
       type: string
     - description: Configured
       jsonPath: .status.conditions[?(@.type=="PlatformInfrastructureConfigured")].status
-      name: INFRA Ready
+      name: Ready
+      type: string
+    - description: Reason
+      jsonPath: .status.conditions[?(@.type=="ProviderSecretConfigured")].reason
+      name: Reference
+      type: string
+    - description: Found
+      jsonPath: .status.conditions[?(@.type=="ProviderSecretConfigured")].status
+      name: Found
       type: string
     name: v1alpha1
     schema:


### PR DESCRIPTION
* Add reconcile log message, so we can better visualize in the logs how often we reconcile
* Change the column labels from Reason to Status
* Remove IAM and INFRA labels as the values are implied
* Remove an errant log entry that just printed a namespace

Signed-off-by: Joshua Packer <jpacker@redhat.com>

@ianzhang366 @zhujian7 I'm interested in your feedback on the column names. Whether the READY needs to have the prefixes IAM and INFRA, as well as the STATUS.
```
NAME       STATUS                                       READY   STATUS                            READY   REFERENCE                           FOUND
sample     PlatformInfrastructureConfiguredAsExpected   True    PlatformIAMConfiguredAsExpected   True    ProviderSecretReferenceAsExpected   True
sample02   PlatformInfrastructureConfiguredAsExpected   False   PlatformIAMBeingConfigured        True    ProviderSecretReferenceAsExpected   True
```

Let me know if you think the status and the Ready labels need the prefixes
```
NAME       INFRA STATUS                                 INFRA READY   IAM STATUS                        IAM READY   REFERENCE                           FOUND
sample     PlatformInfrastructureConfiguredAsExpected   True          PlatformIAMConfiguredAsExpected   True        ProviderSecretReferenceAsExpected   True
sample02   PlatformInfrastructureConfiguredAsExpected   False         PlatformIAMBeingConfigured        True        ProviderSecretReferenceAsExpected   True
```