### PR TITLE
remove vendor from build target in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,11 +65,11 @@ test: manifests generate fmt vet envtest ## Run tests.
 ##@ Build
 .PHONY: vendor
 vendor:
-	go mod vendor
 	go mod tidy -compat=1.17
+	go mod vendor
 
 .PHONY: build
-build: vendor generate fmt vet ## Build manager binary.
+build: generate fmt vet ## Build manager binary.
 	GOFLAGS="" go build -o bin/manager pkg/main.go
 
 .PHONY: run


### PR DESCRIPTION
- According to https://github.com/stolostron/backlog/issues/18754#issuecomment-1039209650, I think we should not execute "go mod tidy" when execute `make build`

Signed-off-by: zhujian <jiazhu@redhat.com>