### PR TITLE
address manifestwork related issues

### DIFF
--- a/config/deployment/kustomization.yaml
+++ b/config/deployment/kustomization.yaml
@@ -2,7 +2,11 @@ resources:
 - ../crd
 - ../rbac
 - template-deployment.yaml
+- https://raw.githubusercontent.com/open-cluster-management-io/api/main/work/v1/0000_00_work.open-cluster-management.io_manifestworks.crd.yaml
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: open-cluster-management
-
+images:
+- name: quay.io/stolostron/hypershift-deployment-controller:latest
+  newName: quay.io/stolostron/hypershift-deployment-controller
+  newTag: latest

--- a/config/deployment/kustomization.yaml
+++ b/config/deployment/kustomization.yaml
@@ -6,7 +6,4 @@ resources:
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: open-cluster-management
-images:
-- name: quay.io/stolostron/hypershift-deployment-controller:latest
-  newName: quay.io/stolostron/hypershift-deployment-controller
-  newTag: latest
+

--- a/pkg/controllers/default-resources.go
+++ b/pkg/controllers/default-resources.go
@@ -47,7 +47,6 @@ func getTargetNamespace(hyd *hypdeployment.HypershiftDeployment) string {
 }
 
 func ScaffoldHostedCluster(hyd *hypdeployment.HypershiftDeployment) *hyp.HostedCluster {
-
 	return &hyp.HostedCluster{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      hyd.Name,

--- a/pkg/controllers/manifestwork.go
+++ b/pkg/controllers/manifestwork.go
@@ -39,7 +39,7 @@ const (
 	NamespaceNameSeperator        = "/"
 )
 
-func ScafoldManifestwork(hyd *hypdeployment.HypershiftDeployment) (*workv1.ManifestWork, error) {
+func ScaffoldManifestwork(hyd *hypdeployment.HypershiftDeployment) (*workv1.ManifestWork, error) {
 	if len(hyd.Spec.InfraID) == 0 {
 		return nil, fmt.Errorf("hypershiftDeployment.Spec.InfraID is not set or rendered")
 	}
@@ -92,7 +92,7 @@ func syncManifestworkStatusToHypershiftDeployment(
 }
 
 func (r *HypershiftDeploymentReconciler) createMainfestwork(ctx context.Context, req ctrl.Request, hyd *hypdeployment.HypershiftDeployment) (ctrl.Result, error) {
-	m, err := ScafoldManifestwork(hyd)
+	m, err := ScaffoldManifestwork(hyd)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -141,7 +141,7 @@ func (r *HypershiftDeploymentReconciler) createMainfestwork(ctx context.Context,
 }
 
 func (r *HypershiftDeploymentReconciler) deleteManifestworkWaitCleanUp(ctx context.Context, hyd *hypdeployment.HypershiftDeployment) (ctrl.Result, error) {
-	m, err := ScafoldManifestwork(hyd)
+	m, err := ScaffoldManifestwork(hyd)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/pkg/controllers/manifestwork.go
+++ b/pkg/controllers/manifestwork.go
@@ -47,8 +47,8 @@ func ScafoldManifestwork(hyd *hypdeployment.HypershiftDeployment) (*workv1.Manif
 	w := &workv1.ManifestWork{
 		TypeMeta: metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{
-			// make sure when deploying 2 same hostedcluster name in different namespace, the
-			// generated manifestwork is unqinue.
+			// make sure when deploying 2 hostedclusters with the same name but in different namespaces, the
+			// generated manifestworks are unqinue.
 			Name:      fmt.Sprintf("%s-%s", hyd.GetName(), hyd.Spec.InfraID),
 			Namespace: getTargetManagedCluster(hyd),
 			Annotations: map[string]string{

--- a/pkg/controllers/manifestwork.go
+++ b/pkg/controllers/manifestwork.go
@@ -39,11 +39,17 @@ const (
 	NamespaceNameSeperator        = "/"
 )
 
-func ScafoldManifestwork(hyd *hypdeployment.HypershiftDeployment) *workv1.ManifestWork {
+func ScafoldManifestwork(hyd *hypdeployment.HypershiftDeployment) (*workv1.ManifestWork, error) {
+	if len(hyd.Spec.InfraID) == 0 {
+		return nil, fmt.Errorf("hypershiftDeployment.Spec.InfraID is not set or rendered")
+	}
+
 	w := &workv1.ManifestWork{
 		TypeMeta: metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      hyd.GetName(),
+			// make sure when deploying 2 same hostedcluster name in different namespace, the
+			// generated manifestwork is unqinue.
+			Name:      fmt.Sprintf("%s-%s", hyd.GetName(), hyd.Spec.InfraID),
 			Namespace: getTargetManagedCluster(hyd),
 			Annotations: map[string]string{
 				CreatedByHypershiftDeployment: fmt.Sprintf("%s%s%s",
@@ -59,7 +65,7 @@ func ScafoldManifestwork(hyd *hypdeployment.HypershiftDeployment) *workv1.Manife
 		w.Spec.DeleteOption = &workv1.DeleteOption{PropagationPolicy: workv1.DeletePropagationPolicyTypeOrphan}
 	}
 
-	return w
+	return w, nil
 }
 
 func getManifestWorkKey(hyd *hypdeployment.HypershiftDeployment) types.NamespacedName {
@@ -86,7 +92,11 @@ func syncManifestworkStatusToHypershiftDeployment(
 }
 
 func (r *HypershiftDeploymentReconciler) createMainfestwork(ctx context.Context, req ctrl.Request, hyd *hypdeployment.HypershiftDeployment) (ctrl.Result, error) {
-	m := ScafoldManifestwork(hyd)
+	m, err := ScafoldManifestwork(hyd)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
 	// if the manifestwork is created, then move the status to hypershiftDeployment
 	// TODO: @ianzhang366 might want to do some upate/patch when the manifestwork is created.
 	if err := r.Get(ctx, getManifestWorkKey(hyd), m); err == nil {
@@ -131,7 +141,10 @@ func (r *HypershiftDeploymentReconciler) createMainfestwork(ctx context.Context,
 }
 
 func (r *HypershiftDeploymentReconciler) deleteManifestworkWaitCleanUp(ctx context.Context, hyd *hypdeployment.HypershiftDeployment) (ctrl.Result, error) {
-	m := ScafoldManifestwork(hyd)
+	m, err := ScafoldManifestwork(hyd)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
 
 	if err := r.Get(ctx, types.NamespacedName{Name: m.GetName(), Namespace: m.GetNamespace()}, m); err != nil {
 		if apierrors.IsNotFound(err) {


### PR DESCRIPTION
- make sure the manifestwork crd is deployed with the operator. [slack](https://coreos.slack.com/archives/C02V40F8BH7/p1645571940220759)
- make sure it can generate unique manifestworks when the multiple hypershiftDeployments, with the same name, in different namespaces, deploy to the same targetManagedCluster. [slack](https://coreos.slack.com/archives/C02V40F8BH7/p1645124012581909)