### PR TITLE
Add an auto import controller to import the hosted cluster

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,8 @@ RUN go mod download
 COPY pkg/main.go pkg/main.go
 COPY api/ api/
 COPY pkg/controllers/ pkg/controllers/
+COPY pkg/helper/ pkg/helper/
+COPY pkg/constant/ pkg/constant/
 #COPY vendor vendor                     # Developer Note: Needs to be retreived for every build
 COPY Makefile Makefile
 COPY hack hack

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -27,6 +27,16 @@ rules:
   - update
   - watch
 - apiGroups:
+  - addon.open-cluster-management.io
+  resources:
+  - managedclusteraddons
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
   - cluster.open-cluster-management.io
   resources:
   - hypershiftdeployments
@@ -53,6 +63,24 @@ rules:
   - patch
   - update
 - apiGroups:
+  - cluster.open-cluster-management.io
+  resources:
+  - managedclusters
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.open-cluster-management.io
+  resources:
+  - managedclustersets/join
+  verbs:
+  - create
+- apiGroups:
   - hypershift.openshift.io
   resources:
   - hostedclusters
@@ -65,6 +93,12 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - register.open-cluster-management.io
+  resources:
+  - managedclusters/accept
+  verbs:
+  - update
 - apiGroups:
   - work.open-cluster-management.io
   resources:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -27,16 +27,6 @@ rules:
   - update
   - watch
 - apiGroups:
-  - addon.open-cluster-management.io
-  resources:
-  - managedclusteraddons
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - watch
-- apiGroups:
   - cluster.open-cluster-management.io
   resources:
   - hypershiftdeployments

--- a/pkg/constant/constants.go
+++ b/pkg/constant/constants.go
@@ -1,7 +1,7 @@
 package constant
 
 const (
-	AnnoHypershiftDeployment = "hypershift.open-cluster-management.io/hypershiftdeployemnt"
+	AnnoHypershiftDeployment = "cluster.open-cluster-management.io/hypershiftdeployment"
 
 	NamespaceNameSeperator = "/"
 )

--- a/pkg/constant/constants.go
+++ b/pkg/constant/constants.go
@@ -2,4 +2,6 @@ package constant
 
 const (
 	AnnoHypershiftDeployment = "hypershift.open-cluster-management.io/hypershiftdeployemnt"
+
+	NamespaceNameSeperator = "/"
 )

--- a/pkg/constant/constants.go
+++ b/pkg/constant/constants.go
@@ -2,16 +2,4 @@ package constant
 
 const (
 	AnnoHypershiftDeployment = "hypershift.open-cluster-management.io/hypershiftdeployemnt"
-
-	DefaultAddonInstallNamespace = "open-cluster-management-agent-addon"
-)
-
-var (
-	// InstallAddons list addons that will be install to the hypershift hosted cluster
-	InstallAddons = []string{
-		"cert-policy-controller",
-		"config-policy-controller",
-		"governance-policy-framework",
-		"iam-policy-controller",
-	}
 )

--- a/pkg/constant/constants.go
+++ b/pkg/constant/constants.go
@@ -1,0 +1,17 @@
+package constant
+
+const (
+	AnnoHypershiftDeployment = "hypershift.open-cluster-management.io/hypershiftdeployemnt"
+
+	DefaultAddonInstallNamespace = "open-cluster-management-agent-addon"
+)
+
+var (
+	// InstallAddons list addons that will be install to the hypershift hosted cluster
+	InstallAddons = []string{
+		"cert-policy-controller",
+		"config-policy-controller",
+		"governance-policy-framework",
+		"iam-policy-controller",
+	}
+)

--- a/pkg/controllers/autoimport/autoimport_controller.go
+++ b/pkg/controllers/autoimport/autoimport_controller.go
@@ -1,0 +1,398 @@
+// Copyright Contributors to the Open Cluster Management project.
+
+package autoimport
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	// kacv1 "github.com/stolostron/klusterlet-addon-controller/pkg/apis/agent/v1"
+	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
+	mcv1 "open-cluster-management.io/api/cluster/v1"
+
+	hypdeployment "github.com/stolostron/hypershift-deployment-controller/api/v1alpha1"
+	"github.com/stolostron/hypershift-deployment-controller/pkg/constant"
+	"github.com/stolostron/hypershift-deployment-controller/pkg/helper"
+)
+
+const DEBUG = 1
+const INFO = 0
+const WARN = -1
+const ERROR = -2
+const FINALIZER = "hypershiftdeployment.cluster.open-cluster-management.io/managedcluster-cleanup"
+const CREATECM = "cluster.open-cluster-management.io/createmanagedcluster"
+
+// Reconciler reconciles a HypershiftDeployment object to
+// import the related hypershift hosted cluster to the hub cluster.
+type Reconciler struct {
+	client.Client
+	Log    logr.Logger
+	Scheme *runtime.Scheme
+}
+
+//+kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=hypershiftdeployments,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=hypershiftdeployments/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=hypershiftdeployments/finalizers,verbs=update
+//+kubebuilder:rbac:groups="",resources=secrets,verbs=create;get;list;watch
+//+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
+//+kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=managedclusters,verbs=create;delete;get;list;patch;update;watch
+//+kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=managedclustersets/join,verbs=create
+//+kubebuilder:rbac:groups=register.open-cluster-management.io,resources=managedclusters/accept,verbs=update
+//+kubebuilder:rbac:groups=addon.open-cluster-management.io,resources=managedclusteraddons,verbs=create;delete;get;list;watch
+
+// Reconcile is part of the main kubernetes reconciliation loop which aims to
+// move the current state of the cluster closer to the desired state.
+// TODO(user): Modify the Reconcile function to compare the state specified by
+// the HypershiftDeployment object against the actual cluster state, and then
+// perform operations to make the cluster state reflect the state specified by
+// the user.
+//
+// For more details, check Reconcile and its Result here:
+// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.10.0/pkg/reconcile
+func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	r.Log = log.FromContext(ctx)
+	log := r.Log.WithValues("AutoImportReconciler", req.NamespacedName)
+
+	var hyd hypdeployment.HypershiftDeployment
+	if err := r.Get(ctx, req.NamespacedName, &hyd); err != nil {
+		log.V(INFO).Info("Resource hypershift deployment deleted")
+		return ctrl.Result{}, nil
+	}
+
+	if len(hyd.Spec.InfraID) == 0 {
+		log.V(INFO).Info("Resource hypershift spec infraID is empty")
+		return ctrl.Result{}, nil
+	}
+
+	log.V(INFO).Info("Hypershift Deployment info", "InfraID", hyd.Spec.InfraID,
+		"targetNamespace", hyd.Spec.TargetNamespace, "targetManagedCluster", hyd.Spec.TargetManagedCluster)
+
+	managedClusterName := helper.ManagedClusterName(&hyd)
+	// Delete the ManagedCluster and Addons
+	if hyd.DeletionTimestamp != nil {
+		if err := deleteResources(r, managedClusterName); err != nil {
+			return ctrl.Result{}, err
+		}
+
+		return ctrl.Result{}, removeFinalizer(r, &hyd)
+	}
+
+	// Do not exit till this point when importmanagedcluster=false, so deletion will work properly if manually imported
+	if len(hyd.Annotations) > 0 {
+		aValue, found := hyd.Annotations[CREATECM]
+		if found && strings.ToLower(aValue) == "false" {
+			log.V(WARN).Info("Skip creation of managedCluster and addons")
+			return ctrl.Result{}, nil
+		}
+	}
+
+	managementClusterName := helper.GetTargetManagedCluster(&hyd)
+	// ManagedCluster
+	managedCluster, err := ensureManagedCluster(r, managedClusterName, managementClusterName)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// Once we are sure there is a ManagedCluster, we set the finalizer
+	if !controllerutil.ContainsFinalizer(&hyd, FINALIZER) {
+		return ctrl.Result{}, setFinalizer(r, &hyd)
+	}
+
+	// Addons
+	err = ensureAddons(r, managedClusterName)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	if !meta.IsStatusConditionTrue(managedCluster.Status.Conditions, mcv1.ManagedClusterConditionJoined) {
+		// Auto import secret
+		var kubeconfig corev1.Secret
+		secretNamespaceName := types.NamespacedName{Namespace: managementClusterName, Name: helper.HostedKubeconfigName(&hyd)}
+		err = r.Get(ctx, secretNamespaceName, &kubeconfig)
+		if k8serrors.IsNotFound(err) {
+			log.V(INFO).Info("Wait for the hosted cluster kubeconfig to be created", "secret", secretNamespaceName.String())
+			return ctrl.Result{}, nil
+		}
+		if err := ensureAutoImportSecret(r, managedClusterName, &kubeconfig); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+
+	return ctrl.Result{}, ensureCreateManagedClusterAnnotationFalse(r, &hyd)
+}
+
+func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
+	syncedFromSpoke := func(object client.Object) bool {
+		return strings.EqualFold(object.GetLabels()["synced-from-spoke"], "true")
+	}
+
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&hypdeployment.HypershiftDeployment{}).
+		// TODO(zhujian7): After https://github.com/stolostron/hypershift-deployment-controller/pull/33 is merged,
+		// we can add a new secret controller to render the kubeConfig in status and remove the watches here.
+		Watches(&source.Kind{Type: &corev1.Secret{}}, handler.EnqueueRequestsFromMapFunc(func(obj client.Object) []reconcile.Request {
+			an := obj.GetAnnotations()
+			if len(an) == 0 || len(an[constant.AnnoHypershiftDeployment]) == 0 {
+				return []reconcile.Request{}
+			}
+
+			res := strings.Split(an[constant.AnnoHypershiftDeployment], "/")
+			if len(res) != 2 {
+				log.Log.Error(fmt.Errorf("failed to get hypershiftDeployment"), "annotation invalid",
+					"constant.AnnoHypershiftDeployment", an[constant.AnnoHypershiftDeployment])
+				return []reconcile.Request{}
+			}
+
+			req := reconcile.Request{
+				NamespacedName: types.NamespacedName{Namespace: res[0], Name: res[1]},
+			}
+			return []reconcile.Request{req}
+		}), builder.WithPredicates(
+			predicate.Funcs{
+				GenericFunc: func(e event.GenericEvent) bool { return false },
+				CreateFunc: func(e event.CreateEvent) bool {
+					return syncedFromSpoke(e.Object)
+				},
+				DeleteFunc: func(e event.DeleteEvent) bool { return false },
+				UpdateFunc: func(e event.UpdateEvent) bool {
+					if !syncedFromSpoke(e.ObjectNew) {
+						return false
+					}
+
+					new, okNew := e.ObjectNew.(*corev1.Secret)
+					old, okOld := e.ObjectOld.(*corev1.Secret)
+					if okNew && okOld {
+						return !equality.Semantic.DeepEqual(old.Data, new.Data)
+					}
+					return false
+				},
+			},
+		)).
+		WithOptions(controller.Options{
+			MaxConcurrentReconciles: 1, // This is the default
+		}).Named("hypershiftimport").Complete(r)
+}
+
+func ensureManagedCluster(r *Reconciler,
+	managedClusterName, managementClusterName string) (*mcv1.ManagedCluster, error) {
+	log := r.Log.WithValues("managedClusterName", managedClusterName)
+	ctx := context.Background()
+
+	var mc mcv1.ManagedCluster
+	err := r.Get(ctx, types.NamespacedName{Name: managedClusterName}, &mc)
+	if k8serrors.IsNotFound(err) {
+		log.V(INFO).Info("Create a new ManagedCluster resource")
+		mc.Name = managedClusterName
+		mc.Spec.HubAcceptsClient = true
+
+		mc.ObjectMeta.Annotations = map[string]string{
+			"import.open-cluster-management.io/klusterlet-deploy-mode":  "Detached",
+			"import.open-cluster-management.io/management-cluster-name": managementClusterName,
+		}
+
+		if err = r.Create(ctx, &mc, &client.CreateOptions{}); err != nil {
+			log.V(ERROR).Info("Could not create ManagedCluster resource", "error", err)
+			return nil, err
+		}
+
+		return &mc, nil
+	}
+
+	if err != nil {
+		log.V(WARN).Info("Error when attempting to retreive the ManagedCluster resource", "error", err)
+		return nil, err
+	}
+
+	return &mc, nil
+}
+
+func ensureAddons(r *Reconciler, namespace string) error {
+	for _, addon := range constant.InstallAddons {
+		if err := ensureManagedClusterAddon(r, namespace, addon); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func ensureManagedClusterAddon(r *Reconciler, namespace, name string) error {
+	log := r.Log.WithValues("addonName", name)
+	ctx := context.Background()
+
+	var addon addonv1alpha1.ManagedClusterAddOn
+	err := r.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, &addon)
+	if k8serrors.IsNotFound(err) {
+
+		log.V(INFO).Info("Create a new ManagedClusterAddon resource")
+		addon.Name = name
+		addon.Namespace = namespace
+		addon.Spec.InstallNamespace = constant.DefaultAddonInstallNamespace
+
+		if err = r.Create(ctx, &addon, &client.CreateOptions{}); err != nil {
+			log.V(ERROR).Info("Could not create ManagedClusterAddon resource")
+			return err
+		}
+
+		return nil
+	}
+	if err != nil {
+		log.V(WARN).Info("Error when attempting to retreive the ManagedClusterAddon resource")
+		return err
+	}
+
+	return nil
+}
+
+func ensureAutoImportSecret(r *Reconciler, managedClusterName string, kubeSecret *corev1.Secret) error {
+	log := r.Log.WithValues("managedClusterName", managedClusterName)
+	ctx := context.Background()
+
+	var secret corev1.Secret
+	/* #nosec */
+	secretName := "auto-import-secret"
+	err := r.Get(ctx, types.NamespacedName{Namespace: managedClusterName, Name: secretName}, &secret)
+	if k8serrors.IsNotFound(err) {
+
+		log.V(INFO).Info("Create a new auto import secret resource")
+		secret.Name = secretName
+		secret.Namespace = managedClusterName
+		secret.Data = kubeSecret.Data
+
+		if err := r.Create(ctx, &secret, &client.CreateOptions{}); err != nil {
+			log.V(ERROR).Info("Could not create auto import secret", "error", err)
+			return err
+		}
+		return nil
+	}
+	if err != nil {
+		log.V(WARN).Info("Error when attempting to retreive the auto import secret", "error", err)
+		return err
+	}
+
+	return nil
+}
+
+func ensureCreateManagedClusterAnnotationFalse(r *Reconciler, hyd *hypdeployment.HypershiftDeployment) error {
+	//Make sure we don't create the ManagedCluster if it is detached, uses the finalizer to update hyd
+	if len(hyd.Annotations) > 0 {
+		hyd.Annotations[CREATECM] = "false"
+	} else {
+		hyd.ObjectMeta.Annotations = map[string]string{CREATECM: "false"}
+	}
+	return r.Update(context.Background(), hyd)
+}
+
+func setFinalizer(r *Reconciler, hyd *hypdeployment.HypershiftDeployment) error {
+	controllerutil.AddFinalizer(hyd, FINALIZER)
+	r.Log.V(INFO).Info("Added finalizer on hypershift deployment: " + hyd.Name)
+	return r.Update(context.Background(), hyd)
+}
+
+func removeFinalizer(r *Reconciler, hyd *hypdeployment.HypershiftDeployment) error {
+	if !controllerutil.ContainsFinalizer(hyd, FINALIZER) {
+		return nil
+	}
+
+	controllerutil.RemoveFinalizer(hyd, FINALIZER)
+
+	r.Log.V(INFO).Info("Removed finalizer on hypershift deployment: " + hyd.Name)
+	return r.Update(context.Background(), hyd)
+
+}
+
+func deleteResources(r *Reconciler, managedClusterName string) error {
+	if err := deleteManagedCluster(r, managedClusterName); err != nil {
+		return err
+	}
+	return deleteAddons(r, managedClusterName)
+}
+
+func deleteManagedCluster(r *Reconciler, name string) error {
+	ctx := context.Background()
+	log := r.Log.WithValues("managedClusterName", name)
+
+	var mc mcv1.ManagedCluster
+	err := r.Get(ctx, types.NamespacedName{Name: name}, &mc)
+	if k8serrors.IsNotFound(err) {
+		log.V(INFO).Info("The ManagedCluster resource was not found, can not delete")
+		return nil
+	}
+	if err != nil {
+		log.V(WARN).Info("Error when attempting to retreive the ManagedCluster resource", "error", err)
+		return err
+	}
+
+	if mc.DeletionTimestamp != nil {
+		log.V(INFO).Info("The managedCluster resource is already being deleted")
+		return nil
+	}
+
+	err = r.Delete(ctx, &mc)
+	if err != nil {
+		log.V(WARN).Info("Error while deleting ManagedCluster resource", "error", err)
+	}
+
+	log.V(INFO).Info("Deleted ManagedCluster resource")
+	return nil
+}
+
+func deleteManagedClusterAddon(r *Reconciler, namespace, name string) error {
+	log := r.Log.WithValues("addonName", name)
+	ctx := context.Background()
+
+	var addon addonv1alpha1.ManagedClusterAddOn
+	err := r.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, &addon)
+	if k8serrors.IsNotFound(err) {
+		log.V(INFO).Info("The ManagedClusterAddon resource was not found, can not delete")
+		return nil
+	}
+	if err != nil {
+		log.V(WARN).Info("Error when attempting to retreive the ManagedClusterAddon resource", "error", err)
+		return err
+	}
+
+	if addon.DeletionTimestamp != nil {
+		log.V(INFO).Info("The ManagedClusterAddon resource is already being deleted")
+		return nil
+	}
+
+	err = r.Delete(ctx, &addon)
+	if err != nil {
+		log.V(WARN).Info("Error while deleting ManagedClusterAddon resource", "error", err)
+		return err
+	}
+
+	log.V(INFO).Info("Deleted ManagedClusterAddon resource")
+	return nil
+}
+
+func deleteAddons(r *Reconciler, namespace string) error {
+	for _, addon := range constant.InstallAddons {
+		if err := deleteManagedClusterAddon(r, namespace, addon); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/controllers/autoimport/autoimport_controller.go
+++ b/pkg/controllers/autoimport/autoimport_controller.go
@@ -197,6 +197,7 @@ func ensureManagedCluster(r *Reconciler, hydNamespaceName types.NamespacedName,
 		mc.Spec.HubAcceptsClient = true
 
 		mc.ObjectMeta.Annotations = map[string]string{
+			// TODO(zhujian7): change `Detached` to `Hosted` after the upstream ocm changes this name.
 			"import.open-cluster-management.io/klusterlet-deploy-mode":  "Detached",
 			"import.open-cluster-management.io/management-cluster-name": managementClusterName,
 			constant.AnnoHypershiftDeployment: fmt.Sprintf("%s%s%s",

--- a/pkg/controllers/autoimport/autoimport_controller_test.go
+++ b/pkg/controllers/autoimport/autoimport_controller_test.go
@@ -4,6 +4,7 @@ package autoimport
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -22,6 +23,7 @@ import (
 	mcv1 "open-cluster-management.io/api/cluster/v1"
 
 	hydapi "github.com/stolostron/hypershift-deployment-controller/api/v1alpha1"
+	"github.com/stolostron/hypershift-deployment-controller/pkg/constant"
 	"github.com/stolostron/hypershift-deployment-controller/pkg/helper"
 )
 
@@ -151,7 +153,8 @@ func TestReconcileCreate(t *testing.T) {
 				mcName := helper.ManagedClusterName(hyd)
 				err := client.Get(ctx, getNamespaceName("", mcName), &mc)
 				assert.Nil(t, err, "when managedCluster resource is retrieved")
-
+				assert.Equal(t, mc.Annotations[constant.AnnoHypershiftDeployment],
+					fmt.Sprintf("%s%s%s", hyd.Namespace, constant.NamespaceNameSeperator, hyd.Name))
 				assertAnnoNotContainCreateCM(t, ctx, client)
 			},
 		},

--- a/pkg/controllers/autoimport/autoimport_controller_test.go
+++ b/pkg/controllers/autoimport/autoimport_controller_test.go
@@ -1,0 +1,287 @@
+// Copyright Contributors to the Open Cluster Management project.
+
+package autoimport
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap/zapcore"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+	clientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
+	mcv1 "open-cluster-management.io/api/cluster/v1"
+
+	hydapi "github.com/stolostron/hypershift-deployment-controller/api/v1alpha1"
+	"github.com/stolostron/hypershift-deployment-controller/pkg/constant"
+	"github.com/stolostron/hypershift-deployment-controller/pkg/helper"
+)
+
+const HYD_NAME = "my-hypershift-deployment"
+const HYD_NAMESPACE = "testns"
+
+var s = clientgoscheme.Scheme
+
+func init() {
+	clientgoscheme.AddToScheme(s)
+
+	hydapi.AddToScheme(s)
+
+	mcv1.AddToScheme(s)
+
+	addonv1alpha1.AddToScheme(s)
+}
+
+func getRequest() ctrl.Request {
+	return getRequestWithNamespaceName(HYD_NAMESPACE, HYD_NAME)
+}
+
+func getRequestWithNamespaceName(rNamespace string, rName string) ctrl.Request {
+	return ctrl.Request{
+		NamespacedName: getNamespaceName(rNamespace, rName),
+	}
+}
+
+func getNamespaceName(namespace string, name string) types.NamespacedName {
+	return types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	}
+}
+
+func GetHypershiftDeployment(namespace string, name string, infraID string) *hydapi.HypershiftDeployment {
+	return &hydapi.HypershiftDeployment{
+		ObjectMeta: v1.ObjectMeta{
+			Name:       name,
+			Namespace:  namespace,
+			Finalizers: []string{FINALIZER},
+		},
+		Spec: hydapi.HypershiftDeploymentSpec{
+			InfraID: infraID,
+		},
+	}
+}
+
+func GetManagedCluster(name string) *mcv1.ManagedCluster {
+	return &mcv1.ManagedCluster{
+		ObjectMeta: v1.ObjectMeta{
+			Name: name,
+		},
+		Spec: mcv1.ManagedClusterSpec{
+			HubAcceptsClient: true,
+		},
+	}
+}
+
+func setAnnotationHYD(hyd *hydapi.HypershiftDeployment, annotations map[string]string) *hydapi.HypershiftDeployment {
+	hyd.SetAnnotations(annotations)
+	return hyd
+}
+
+func setFinalizerHYD(hyd *hydapi.HypershiftDeployment, finalizer []string) *hydapi.HypershiftDeployment {
+	hyd.SetFinalizers(finalizer)
+	return hyd
+}
+
+func setDeletionTimestamp(hyd *hydapi.HypershiftDeployment, deletionTimestamp time.Time) *hydapi.HypershiftDeployment {
+	hyd.SetDeletionTimestamp(&v1.Time{Time: deletionTimestamp})
+	return hyd
+}
+
+func GetHostedClusterKubeconfig(namespace string, name string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Data: map[string][]byte{
+			"kubeconfig": []byte("test"),
+		},
+	}
+}
+
+func GetAutoImportReconciler() *Reconciler {
+	// Log levels: DebugLevel  DebugLevel
+	ctrl.SetLogger(zap.New(zap.UseDevMode(true), zap.Level(zapcore.DebugLevel)))
+
+	return &Reconciler{
+		Client: clientfake.NewClientBuilder().WithScheme(s).Build(),
+		Log:    ctrl.Log.WithName("controllers").WithName("AutoImportReconciler"),
+		Scheme: s,
+	}
+}
+
+func assertAnnoCreateCMFalse(t *testing.T, ctx context.Context, client crclient.Client) {
+	var hyd hydapi.HypershiftDeployment
+	err := client.Get(ctx, getNamespaceName(HYD_NAMESPACE, HYD_NAME), &hyd)
+	assert.Nil(t, err, "hypershift deployment resource is retrieved")
+	assert.Contains(t, hyd.Annotations, CREATECM, "annotation should contain create cm")
+	assert.Equal(t, hyd.Annotations[CREATECM], "false", "assert annotation value be false")
+}
+
+func assertAnnoNotContainCreateCM(t *testing.T, ctx context.Context, client crclient.Client) {
+	var hyd hydapi.HypershiftDeployment
+	err := client.Get(ctx, getNamespaceName(HYD_NAMESPACE, HYD_NAME), &hyd)
+	assert.Nil(t, err, "hypershift deployment resource is retrieved")
+	assert.NotContains(t, hyd.Annotations, CREATECM, "annotation should not contain create cm")
+}
+
+func TestReconcileCreate(t *testing.T) {
+	hyd := GetHypershiftDeployment(HYD_NAMESPACE, HYD_NAME, "id1")
+
+	cases := []struct {
+		name            string
+		kubesecret      *corev1.Secret
+		hyd             *hydapi.HypershiftDeployment
+		validateActions func(t *testing.T, ctx context.Context, client crclient.Client)
+		expectedErr     string
+	}{
+		{
+			name:       "create managed cluster and addons",
+			kubesecret: nil,
+			hyd:        hyd.DeepCopy(),
+			validateActions: func(t *testing.T, ctx context.Context, client crclient.Client) {
+				var mc mcv1.ManagedCluster
+				mcName := helper.ManagedClusterName(hyd)
+				err := client.Get(ctx, getNamespaceName("", mcName), &mc)
+				assert.Nil(t, err, "when managedCluster resource is retrieved")
+
+				var addons addonv1alpha1.ManagedClusterAddOnList
+				err = client.List(ctx, &addons, &crclient.ListOptions{Namespace: mcName})
+				assert.Nil(t, err, "list addons")
+				assert.Equal(t, len(addons.Items), len(constant.InstallAddons), "addon count")
+				assertAnnoNotContainCreateCM(t, ctx, client)
+			},
+		},
+		{
+			name:       "create managed cluster, addons and secret",
+			kubesecret: GetHostedClusterKubeconfig(HYD_NAMESPACE, helper.HostedKubeconfigName(hyd)),
+			hyd:        hyd.DeepCopy(),
+			validateActions: func(t *testing.T, ctx context.Context, client crclient.Client) {
+				var mc mcv1.ManagedCluster
+				err := client.Get(ctx, getNamespaceName("", helper.ManagedClusterName(hyd)), &mc)
+				assert.Nil(t, err, "managedCluster resource is retrieved")
+
+				var autoImportSecret corev1.Secret
+				err = client.Get(ctx, getNamespaceName(mc.Name, "auto-import-secret"), &autoImportSecret)
+				assert.Nil(t, err, "managedCluster resource is retrieved")
+
+				var addons addonv1alpha1.ManagedClusterAddOnList
+				err = client.List(ctx, &addons)
+				assert.Nil(t, err, "list addons")
+				assert.Equal(t, len(addons.Items), len(constant.InstallAddons), "addon count")
+
+				assertAnnoCreateCMFalse(t, ctx, client)
+			},
+		},
+		{
+			name:       "should not create managed cluster, annotation false",
+			kubesecret: GetHostedClusterKubeconfig(HYD_NAMESPACE, helper.HostedKubeconfigName(hyd)),
+			hyd:        setAnnotationHYD(hyd.DeepCopy(), map[string]string{CREATECM: "false"}),
+			validateActions: func(t *testing.T, ctx context.Context, client crclient.Client) {
+				var mc mcv1.ManagedCluster
+				err := client.Get(ctx, getNamespaceName("", helper.ManagedClusterName(hyd)), &mc)
+				assert.True(t, k8serrors.IsNotFound(err), "managed cluster not found")
+			},
+		},
+		{
+			name:       "should not create managed cluster, just add finalizer",
+			kubesecret: GetHostedClusterKubeconfig(HYD_NAMESPACE, helper.HostedKubeconfigName(hyd)),
+			hyd:        setFinalizerHYD(hyd.DeepCopy(), []string{}),
+			validateActions: func(t *testing.T, ctx context.Context, client crclient.Client) {
+				var mc mcv1.ManagedCluster
+				err := client.Get(ctx, getNamespaceName("", helper.ManagedClusterName(hyd)), &mc)
+				assert.Nil(t, err, "managedCluster resource is retrieved")
+
+				var addons addonv1alpha1.ManagedClusterAddOnList
+				err = client.List(ctx, &addons)
+				assert.Nil(t, err, "list addons")
+				assert.Equal(t, len(addons.Items), 0, "addon count")
+
+				assertAnnoNotContainCreateCM(t, ctx, client)
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ctx := context.Background()
+			air := GetAutoImportReconciler()
+
+			if c.hyd != nil {
+				assert.Nil(t, air.Client.Create(ctx, c.hyd, &crclient.CreateOptions{}), "")
+			}
+			if c.kubesecret != nil {
+				assert.Nil(t, air.Client.Create(ctx, c.kubesecret, &crclient.CreateOptions{}), "")
+			}
+
+			_, err := air.Reconcile(ctx, getRequest())
+			assert.Nil(t, err, "reconcile was successful")
+			c.validateActions(t, ctx, air.Client)
+		})
+	}
+}
+
+func TestReconcileDelete(t *testing.T) {
+	hyd := GetHypershiftDeployment(HYD_NAMESPACE, HYD_NAME, "id1")
+
+	cases := []struct {
+		name            string
+		managedcluster  *mcv1.ManagedCluster
+		hyd             *hydapi.HypershiftDeployment
+		validateActions func(t *testing.T, ctx context.Context, client crclient.Client)
+		expectedErr     string
+	}{
+		{
+			name:           "delete managed cluster",
+			managedcluster: GetManagedCluster(helper.ManagedClusterName(hyd)),
+			hyd:            setDeletionTimestamp(hyd.DeepCopy(), time.Now()),
+			validateActions: func(t *testing.T, ctx context.Context, client crclient.Client) {
+				var mc mcv1.ManagedCluster
+				mcName := helper.ManagedClusterName(hyd)
+				err := client.Get(ctx, getNamespaceName("", mcName), &mc)
+				assert.True(t, k8serrors.IsNotFound(err), "no managed cluster found")
+			},
+		},
+		{
+			name:           "delete managed cluster, no managed cluster created",
+			managedcluster: nil,
+			hyd:            setDeletionTimestamp(hyd.DeepCopy(), time.Now()),
+			validateActions: func(t *testing.T, ctx context.Context, client crclient.Client) {
+				var mc mcv1.ManagedCluster
+				mcName := helper.ManagedClusterName(hyd)
+				err := client.Get(ctx, getNamespaceName("", mcName), &mc)
+				assert.True(t, k8serrors.IsNotFound(err), "no managed cluster found")
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ctx := context.Background()
+			air := GetAutoImportReconciler()
+
+			if c.managedcluster != nil {
+				assert.Nil(t, air.Client.Create(ctx, c.managedcluster, &crclient.CreateOptions{}), "")
+			}
+
+			if c.hyd != nil {
+				assert.Nil(t, air.Client.Create(ctx, c.hyd, &crclient.CreateOptions{}), "")
+			}
+
+			_, err := air.Reconcile(ctx, getRequest())
+			assert.Nil(t, err, "reconcile was successful")
+			c.validateActions(t, ctx, air.Client)
+		})
+	}
+}

--- a/pkg/controllers/configuration.go
+++ b/pkg/controllers/configuration.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	hypdeployment "github.com/stolostron/hypershift-deployment-controller/api/v1alpha1"
+	"github.com/stolostron/hypershift-deployment-controller/pkg/helper"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -162,7 +163,7 @@ func (r *HypershiftDeploymentReconciler) ensureConfiguration(ctx context.Context
 
 		for _, se := range secretRefs {
 			k := genKey(se, hyd)
-			t, err := r.generateSecret(ctx, k, overrideNamespace(getTargetNamespace(hyd)))
+			t, err := r.generateSecret(ctx, k, overrideNamespace(helper.GetTargetNamespace(hyd)))
 			if err != nil {
 				r.Log.Error(err, fmt.Sprintf("failed to copy secret %s", k))
 				allErr = append(allErr, err)
@@ -174,7 +175,7 @@ func (r *HypershiftDeploymentReconciler) ensureConfiguration(ctx context.Context
 
 		for _, cm := range configMapRefs {
 			k := genKey(cm, hyd)
-			t, err := r.generateConfigMap(ctx, k, overrideNamespace(getTargetNamespace(hyd)))
+			t, err := r.generateConfigMap(ctx, k, overrideNamespace(helper.GetTargetNamespace(hyd)))
 			if err != nil {
 				r.Log.Error(err, fmt.Sprintf("failed to copy secret %s", k))
 				allErr = append(allErr, err)

--- a/pkg/controllers/default-resources.go
+++ b/pkg/controllers/default-resources.go
@@ -26,6 +26,8 @@ import (
 	"github.com/openshift/hypershift/cmd/util"
 	"github.com/openshift/hypershift/cmd/version"
 	hypdeployment "github.com/stolostron/hypershift-deployment-controller/api/v1alpha1"
+	"github.com/stolostron/hypershift-deployment-controller/pkg/constant"
+	"github.com/stolostron/hypershift-deployment-controller/pkg/helper"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -48,26 +50,13 @@ func getReleaseImagePullSpec() string {
 
 }
 
-func getTargetNamespace(hyd *hypdeployment.HypershiftDeployment) string {
-	t := hyd.GetNamespace()
-	defer func() { resLog.Info(fmt.Sprintf("targetNamespace is: %s", t)) }()
-
-	if len(hyd.Spec.TargetNamespace) == 0 {
-		return t
-	}
-
-	t = hyd.Spec.TargetNamespace
-
-	return t
-}
-
 func ScaffoldHostedCluster(hyd *hypdeployment.HypershiftDeployment) *hyp.HostedCluster {
 	return &hyp.HostedCluster{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      hyd.Name,
-			Namespace: getTargetNamespace(hyd),
+			Namespace: helper.GetTargetNamespace(hyd),
 			Annotations: map[string]string{
-				"hypershift.open-cluster-management.io/hypershiftdeployemnt": fmt.Sprintf("%s/%s", hyd.Namespace, hyd.Name),
+				constant.AnnoHypershiftDeployment: fmt.Sprintf("%s/%s", hyd.Namespace, hyd.Name),
 			},
 		},
 		Spec: *hyd.Spec.HostedClusterSpec,
@@ -275,7 +264,7 @@ func ScaffoldNodePool(hyd *hypdeployment.HypershiftDeployment, np *hypdeployment
 	return &hyp.NodePool{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      np.Name,
-			Namespace: getTargetNamespace(hyd),
+			Namespace: helper.GetTargetNamespace(hyd),
 			Labels: map[string]string{
 				AutoInfraLabelName: hyd.Spec.InfraID,
 			},
@@ -294,7 +283,7 @@ func ScaffoldSecrets(hyd *hypdeployment.HypershiftDeployment) []*corev1.Secret {
 				APIVersion: corev1.SchemeGroupVersion.String(),
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Namespace: getTargetNamespace(hyd),
+				Namespace: helper.GetTargetNamespace(hyd),
 				Name:      name,
 				Labels: map[string]string{
 					AutoInfraLabelName: hyd.Spec.InfraID,
@@ -324,7 +313,7 @@ func ScaffoldAzureCloudCredential(hyd *hypdeployment.HypershiftDeployment, creds
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      hyd.Name + CCredsSuffix,
-			Namespace: getTargetNamespace(hyd),
+			Namespace: helper.GetTargetNamespace(hyd),
 			Labels: map[string]string{
 				util.AutoInfraLabelName: hyd.Spec.InfraID,
 			},

--- a/pkg/controllers/hypershiftdeployment_controller.go
+++ b/pkg/controllers/hypershiftdeployment_controller.go
@@ -41,6 +41,7 @@ import (
 	hyp "github.com/openshift/hypershift/api/v1alpha1"
 	"github.com/openshift/hypershift/cmd/util"
 	hypdeployment "github.com/stolostron/hypershift-deployment-controller/api/v1alpha1"
+	"github.com/stolostron/hypershift-deployment-controller/pkg/constant"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	utilrand "k8s.io/apimachinery/pkg/util/rand"
 	workv1 "open-cluster-management.io/api/work/v1"
@@ -481,7 +482,7 @@ func (r *HypershiftDeploymentReconciler) SetupWithManager(mgr ctrl.Manager) erro
 					return []reconcile.Request{}
 				}
 
-				res := strings.Split(an[CreatedByHypershiftDeployment], NamespaceNameSeperator)
+				res := strings.Split(an[CreatedByHypershiftDeployment], constant.NamespaceNameSeperator)
 
 				if len(res) != 2 {
 					r.Log.Error(fmt.Errorf("failed to get manifestwork's hypershiftDeployment"), "")

--- a/pkg/controllers/hypershiftdeployment_controller_test.go
+++ b/pkg/controllers/hypershiftdeployment_controller_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/openshift/hypershift/cmd/infra/aws"
 	"github.com/openshift/hypershift/cmd/infra/azure"
 	hyd "github.com/stolostron/hypershift-deployment-controller/api/v1alpha1"
+	"github.com/stolostron/hypershift-deployment-controller/pkg/helper"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
@@ -281,7 +282,7 @@ func TestManifestWorkFlow(t *testing.T) {
 
 	manifestWorkKey := types.NamespacedName{
 		Name:      generateManifestName(testHD),
-		Namespace: getTargetManagedCluster(testHD)}
+		Namespace: helper.GetTargetManagedCluster(testHD)}
 
 	manifestWork := &workv1.ManifestWork{}
 
@@ -303,25 +304,25 @@ func TestManifestWorkFlow(t *testing.T) {
 			GroupVersionKind: schema.GroupVersionKind{
 				Group: "", Version: "v1", Kind: "Secret"},
 			NamespacedName: types.NamespacedName{
-				Name: "test1-node-mgmt-creds", Namespace: getTargetNamespace(testHD)}}: false,
+				Name: "test1-node-mgmt-creds", Namespace: helper.GetTargetNamespace(testHD)}}: false,
 
 		kindAndKey{
 			GroupVersionKind: schema.GroupVersionKind{
 				Group: "", Version: "v1", Kind: "Secret"},
 			NamespacedName: types.NamespacedName{
-				Name: "test1-cpo-creds", Namespace: getTargetNamespace(testHD)}}: false,
+				Name: "test1-cpo-creds", Namespace: helper.GetTargetNamespace(testHD)}}: false,
 
 		kindAndKey{
 			GroupVersionKind: schema.GroupVersionKind{
 				Group: "", Version: "v1", Kind: "Secret"},
 			NamespacedName: types.NamespacedName{
-				Name: "test1-node-mgmt-creds", Namespace: getTargetNamespace(testHD)}}: false,
+				Name: "test1-node-mgmt-creds", Namespace: helper.GetTargetNamespace(testHD)}}: false,
 
 		kindAndKey{
 			GroupVersionKind: schema.GroupVersionKind{
 				Group: "", Version: "v1", Kind: "Secret"},
 			NamespacedName: types.NamespacedName{
-				Name: "test1-pull-secret", Namespace: getTargetNamespace(testHD)}}: false,
+				Name: "test1-pull-secret", Namespace: helper.GetTargetNamespace(testHD)}}: false,
 	}
 
 	wl := manifestWork.Spec.Workload.Manifests
@@ -447,7 +448,7 @@ func TestManifestWorkFlowWithExtraConfigurations(t *testing.T) {
 
 	manifestWorkKey := types.NamespacedName{
 		Name:      generateManifestName(testHD),
-		Namespace: getTargetManagedCluster(testHD)}
+		Namespace: helper.GetTargetManagedCluster(testHD)}
 
 	manifestWork := &workv1.ManifestWork{}
 
@@ -459,19 +460,19 @@ func TestManifestWorkFlowWithExtraConfigurations(t *testing.T) {
 			GroupVersionKind: schema.GroupVersionKind{
 				Group: "", Version: "v1", Kind: "Secret"},
 			NamespacedName: types.NamespacedName{
-				Name: cfgSecretName, Namespace: getTargetNamespace(testHD)}}: false,
+				Name: cfgSecretName, Namespace: helper.GetTargetNamespace(testHD)}}: false,
 
 		kindAndKey{
 			GroupVersionKind: schema.GroupVersionKind{
 				Group: "", Version: "v1", Kind: "Secret"},
 			NamespacedName: types.NamespacedName{
-				Name: cfgItemSecretName, Namespace: getTargetNamespace(testHD)}}: false,
+				Name: cfgItemSecretName, Namespace: helper.GetTargetNamespace(testHD)}}: false,
 
 		kindAndKey{
 			GroupVersionKind: schema.GroupVersionKind{
 				Group: "", Version: "v1", Kind: "ConfigMap"},
 			NamespacedName: types.NamespacedName{
-				Name: cfgConfigName, Namespace: getTargetNamespace(testHD)}}: false,
+				Name: cfgConfigName, Namespace: helper.GetTargetNamespace(testHD)}}: false,
 	}
 
 	wl := manifestWork.Spec.Workload.Manifests

--- a/pkg/controllers/manifestwork.go
+++ b/pkg/controllers/manifestwork.go
@@ -33,13 +33,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	hypdeployment "github.com/stolostron/hypershift-deployment-controller/api/v1alpha1"
+	"github.com/stolostron/hypershift-deployment-controller/pkg/constant"
 	"github.com/stolostron/hypershift-deployment-controller/pkg/helper"
 )
 
 const (
 	ManifestTargetNamespace       = "manifestwork-target-namespace"
 	CreatedByHypershiftDeployment = "hypershift-deployment.open-cluster-management.io/created-by"
-	NamespaceNameSeperator        = "/"
 )
 
 //loadManifest will get hostedclsuter's crs and put them to the manifest array
@@ -64,7 +64,7 @@ func ScaffoldManifestwork(hyd *hypdeployment.HypershiftDeployment) (*workv1.Mani
 			Annotations: map[string]string{
 				CreatedByHypershiftDeployment: fmt.Sprintf("%s%s%s",
 					hyd.GetNamespace(),
-					NamespaceNameSeperator,
+					constant.NamespaceNameSeperator,
 					hyd.GetName()),
 			},
 		},

--- a/pkg/helper/helpers.go
+++ b/pkg/helper/helpers.go
@@ -2,7 +2,6 @@ package helper
 
 import (
 	"fmt"
-	"strings"
 
 	hypdeployment "github.com/stolostron/hypershift-deployment-controller/api/v1alpha1"
 )
@@ -25,10 +24,7 @@ func GetTargetNamespace(hyd *hypdeployment.HypershiftDeployment) string {
 }
 
 func ManagedClusterName(hyd *hypdeployment.HypershiftDeployment) string {
-	if strings.HasPrefix(hyd.Spec.InfraID, hyd.GetName()) {
-		return hyd.Spec.InfraID
-	}
-	return fmt.Sprintf("%s-%s", hyd.GetName(), hyd.Spec.InfraID)
+	return hyd.Spec.InfraID
 }
 
 // TODO(zhujian7) get this from hyd.Status.Kubeconfig

--- a/pkg/helper/helpers.go
+++ b/pkg/helper/helpers.go
@@ -1,0 +1,37 @@
+package helper
+
+import (
+	"fmt"
+	"strings"
+
+	hypdeployment "github.com/stolostron/hypershift-deployment-controller/api/v1alpha1"
+)
+
+//TODO @ianzhang366 integrate with the clusterSet logic
+func GetTargetManagedCluster(hyd *hypdeployment.HypershiftDeployment) string {
+	if len(hyd.Spec.TargetManagedCluster) == 0 {
+		return hyd.GetNamespace()
+	}
+
+	return hyd.Spec.TargetManagedCluster
+}
+
+func GetTargetNamespace(hyd *hypdeployment.HypershiftDeployment) string {
+	if len(hyd.Spec.TargetNamespace) == 0 {
+		return hyd.GetNamespace()
+	}
+
+	return hyd.Spec.TargetNamespace
+}
+
+func ManagedClusterName(hyd *hypdeployment.HypershiftDeployment) string {
+	if strings.HasPrefix(hyd.Spec.InfraID, hyd.GetName()) {
+		return hyd.Spec.InfraID
+	}
+	return fmt.Sprintf("%s-%s", hyd.GetName(), hyd.Spec.InfraID)
+}
+
+// TODO(zhujian7) get this from hyd.Status.Kubeconfig
+func HostedKubeconfigName(hyd *hypdeployment.HypershiftDeployment) string {
+	return fmt.Sprintf("%s-%s-admin-kubeconfig", GetTargetNamespace(hyd), hyd.GetName())
+}

--- a/pkg/main.go
+++ b/pkg/main.go
@@ -32,7 +32,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
-	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	mcv1 "open-cluster-management.io/api/cluster/v1"
 	workv1 "open-cluster-management.io/api/work/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -58,8 +57,6 @@ func init() {
 	utilruntime.Must(workv1.AddToScheme(scheme))
 
 	utilruntime.Must(mcv1.AddToScheme(scheme))
-
-	utilruntime.Must(addonv1alpha1.AddToScheme(scheme))
 
 	//+kubebuilder:scaffold:scheme
 }

--- a/pkg/main.go
+++ b/pkg/main.go
@@ -25,19 +25,22 @@ import (
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
+	"github.com/go-logr/logr"
+	"github.com/go-logr/zapr"
+	hyp "github.com/openshift/hypershift/api/v1alpha1"
+	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
+	mcv1 "open-cluster-management.io/api/cluster/v1"
 	workv1 "open-cluster-management.io/api/work/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 
-	"github.com/go-logr/logr"
-	"github.com/go-logr/zapr"
-	hyp "github.com/openshift/hypershift/api/v1alpha1"
 	clusteropenclustermanagementiov1alpha1 "github.com/stolostron/hypershift-deployment-controller/api/v1alpha1"
 	"github.com/stolostron/hypershift-deployment-controller/pkg/controllers"
-	"go.uber.org/zap"
+	"github.com/stolostron/hypershift-deployment-controller/pkg/controllers/autoimport"
 	//+kubebuilder:scaffold:imports
 )
 
@@ -53,6 +56,10 @@ func init() {
 	utilruntime.Must(hyp.AddToScheme(scheme))
 
 	utilruntime.Must(workv1.AddToScheme(scheme))
+
+	utilruntime.Must(mcv1.AddToScheme(scheme))
+
+	utilruntime.Must(addonv1alpha1.AddToScheme(scheme))
 
 	//+kubebuilder:scaffold:scheme
 }
@@ -101,6 +108,14 @@ func main() {
 		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "HypershiftDeployment")
+		os.Exit(1)
+	}
+
+	if err = (&autoimport.Reconciler{
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "AutoImport")
 		os.Exit(1)
 	}
 	//+kubebuilder:scaffold:builder


### PR DESCRIPTION
Signed-off-by: zhujian <jiazhu@redhat.com>
issue: https://github.com/stolostron/backlog/issues/20036

- Add a new auto import controller that will create a mangedcluster after the hypershiftdeployment created, and if there exists hosted cluster kubeconfig, it will also create an auto-import-secret to make the managed hosted cluster available.
- Put some common func to the `helper` package

Next will
- [ ] there is still a problem with the addon: Policy-related addons belong to ACM, but we are trying to use hypershift-deployment-controller to enable policy addons, it makes MCE control ACM addons, we need to find a proper way. 