### PR TITLE
Add hypershift deployment annotation to hosted cluster

### DIFF
--- a/pkg/controllers/default-resources.go
+++ b/pkg/controllers/default-resources.go
@@ -51,6 +51,9 @@ func ScaffoldHostedCluster(hyd *hypdeployment.HypershiftDeployment) *hyp.HostedC
 		ObjectMeta: v1.ObjectMeta{
 			Name:      hyd.Name,
 			Namespace: getTargetNamespace(hyd),
+			Annotations: map[string]string{
+				"hypershift.open-cluster-management.io/hypershiftdeployemnt": fmt.Sprintf("%s/%s", hyd.Namespace, hyd.Name),
+			},
 		},
 		Spec: *hyd.Spec.HostedClusterSpec,
 	}


### PR DESCRIPTION
Signed-off-by: zhujian <jiazhu@redhat.com>

After adding this, the hypershift-addon-operator can make the mirror hosted cluster kubeconfig with hypershift deployment information.

Next:
-  Add a secretController to watch these secrets, and record the secret ref to the `hyp.Status.KubeConfig` and `hyp.Status.KubeadminPassword` after https://github.com/stolostron/hypershift-deployment-controller/pull/33 merged.
- Alternative option: Let the hypershift-addon agent update the `hyp.Status.KubeConfig` and `hyp.Status.KubeadminPassword` directly, but that means the hypershift-addon-operator will depend on the hypershift-deployment-operator.