### PR TITLE
use infraID as manifestwork name

### DIFF
--- a/pkg/controllers/manifestwork.go
+++ b/pkg/controllers/manifestwork.go
@@ -45,7 +45,7 @@ const (
 type loadManifest func(*hypdeployment.HypershiftDeployment, *[]workv1.Manifest) error
 
 func generateManifestName(hyd *hypdeployment.HypershiftDeployment) string {
-	return fmt.Sprintf("%s-%s", hyd.GetName(), hyd.Spec.InfraID)
+	return hyd.Spec.InfraID
 }
 
 func ScaffoldManifestwork(hyd *hypdeployment.HypershiftDeployment) (*workv1.ManifestWork, error) {


### PR DESCRIPTION

Signed-off-by: Ian Zhang <izhang@redhat.com>