### PR TITLE
Fix for issue 20823

### DIFF
--- a/api/v1alpha1/hypershiftdeployment_types.go
+++ b/api/v1alpha1/hypershiftdeployment_types.go
@@ -57,6 +57,8 @@ const (
 	// WorkDegraded represents that the current state of work does not match
 	// the desired state for a certain period.
 	WorkDegraded ConditionType = "Degraded"
+	// WorkConfigured indicates the status of applying the ManifestWork
+	WorkConfigured ConditionType = "ManifestWorkConfigured"
 
 	InfraOverrideDestroy       = "ORPHAN"
 	InfraConfigureOnly         = "INFRA-ONLY"

--- a/pkg/controllers/autoimport/autoimport_controller.go
+++ b/pkg/controllers/autoimport/autoimport_controller.go
@@ -288,7 +288,7 @@ func deleteManagedCluster(r *Reconciler, name string) error {
 	var mc mcv1.ManagedCluster
 	err := r.Get(ctx, types.NamespacedName{Name: name}, &mc)
 	if k8serrors.IsNotFound(err) {
-		log.V(INFO).Info("The ManagedCluster resource was not found, can not delete")
+		log.V(INFO).Info("The ManagedCluster resource was not found, skipped")
 		return nil
 	}
 	if err != nil {

--- a/pkg/controllers/hypershiftdeployment_controller.go
+++ b/pkg/controllers/hypershiftdeployment_controller.go
@@ -444,7 +444,8 @@ func (r *HypershiftDeploymentReconciler) destroyHypershift(hyd *hypdeployment.Hy
 		}
 	}
 
-	if hyd.Spec.Override != hypdeployment.InfraOverrideDestroy {
+	if hyd.Spec.Override != hypdeployment.InfraOverrideDestroy &&
+		hyd.Spec.Infrastructure.Configure {
 		// Infrastructure is the last step
 		if hyd.Spec.Infrastructure.Platform.AWS != nil {
 			if result, err := r.destroyAWSInfrastructure(hyd, providerSecret); err != nil {

--- a/pkg/controllers/manifestwork.go
+++ b/pkg/controllers/manifestwork.go
@@ -107,7 +107,7 @@ func (r *HypershiftDeploymentReconciler) createMainfestwork(ctx context.Context,
 	// Check that a valid spec is present and update the hypershiftDeployment.status.conditions
 	// Since you can omit the nodePool, we only check hostedClusterSpec
 	if hyd.Spec.HostedClusterSpec == nil {
-		r.updateStatusConditionsOnChange(hyd, hypdeployment.WorkConfigured, metav1.ConditionFalse, "HostedClusterSpec is missing", hypdeployment.MisConfiguredReason)
+		_ = r.updateStatusConditionsOnChange(hyd, hypdeployment.WorkConfigured, metav1.ConditionFalse, "HostedClusterSpec is missing", hypdeployment.MisConfiguredReason)
 		r.Log.Error(errors.New("missing value = nil"), "hypershiftDeployment.Spec.HostedClusterSpec is nil")
 		return ctrl.Result{}, nil
 	}

--- a/pkg/controllers/manifestwork.go
+++ b/pkg/controllers/manifestwork.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -102,6 +103,15 @@ func syncManifestworkStatusToHypershiftDeployment(
 }
 
 func (r *HypershiftDeploymentReconciler) createMainfestwork(ctx context.Context, req ctrl.Request, hyd *hypdeployment.HypershiftDeployment, providerSecret *corev1.Secret) (ctrl.Result, error) {
+
+	// Check that a valid spec is present and update the hypershiftDeployment.status.conditions
+	// Since you can omit the nodePool, we only check hostedClusterSpec
+	if hyd.Spec.HostedClusterSpec == nil {
+		r.updateStatusConditionsOnChange(hyd, hypdeployment.WorkConfigured, metav1.ConditionFalse, "HostedClusterSpec is missing", hypdeployment.MisConfiguredReason)
+		r.Log.Error(errors.New("missing value = nil"), "hypershiftDeployment.Spec.HostedClusterSpec is nil")
+		return ctrl.Result{}, nil
+	}
+
 	m, err := ScaffoldManifestwork(hyd)
 	if err != nil {
 		return ctrl.Result{}, err


### PR DESCRIPTION
1. When Configure: false, and no HostedClusterspec, make sure to log an error, set a condition and requeue gracefully
2. On Delete, make sure that the finalizer does not get stuck, waiting for infrastructure to delete that should not be present. Also make sure the manifestWork delete continues when there is NO manifestWork.
3. Add test case to cover this scenario. test includes a check for the NEW condition and that delete is successful.

Signed-off-by: Joshua Packer <jpacker@redhat.com>

Issue reference: https://github.com/stolostron/backlog/issues/20823