### PR TITLE
Get oidc info from secret when using manifestwork

### DIFF
--- a/pkg/controllers/aws_infra_test.go
+++ b/pkg/controllers/aws_infra_test.go
@@ -1,0 +1,155 @@
+package controllers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap/zapcore"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+	clientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	hydapi "github.com/stolostron/hypershift-deployment-controller/api/v1alpha1"
+)
+
+var s = clientgoscheme.Scheme
+
+func init() {
+	clientgoscheme.AddToScheme(s)
+}
+
+func GetHypershiftDeployment(namespace string, name string, targetManagedCluster string, override hydapi.InfraOverride) *hydapi.HypershiftDeployment {
+	return &hydapi.HypershiftDeployment{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: hydapi.HypershiftDeploymentSpec{
+			TargetManagedCluster: targetManagedCluster,
+			Override:             override,
+		},
+	}
+}
+
+func GetHypershiftDeploymentReconciler() *HypershiftDeploymentReconciler {
+	// Log levels: DebugLevel  DebugLevel
+	ctrl.SetLogger(zap.New(zap.UseDevMode(true), zap.Level(zapcore.DebugLevel)))
+
+	return &HypershiftDeploymentReconciler{
+		Client: clientfake.NewClientBuilder().WithScheme(s).Build(),
+		Log:    ctrl.Log.WithName("controllers").WithName("HypershiftDeploymentReconciler"),
+		Scheme: s,
+		ctx:    context.TODO(),
+	}
+}
+
+func TestOidcDiscoveryURL(t *testing.T) {
+	cases := []struct {
+		name         string
+		existObj     crclient.Object
+		hyd          *hydapi.HypershiftDeployment
+		expectedErr  string
+		expectBucket string
+		expectRegion string
+	}{
+		{
+			name: "get info from secret successfully",
+			existObj: &corev1.Secret{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      hypershiftBucketSecretName,
+					Namespace: "test",
+				},
+				Data: map[string][]byte{
+					"bucket": []byte("bucket1"),
+					"region": []byte("region1"),
+				},
+			},
+			hyd:          GetHypershiftDeployment("test", "hyd1", "", hydapi.InfraConfigureWithManifest),
+			expectBucket: "bucket1",
+			expectRegion: "region1",
+		},
+		{
+			name: "get info from secret with specific management cluster",
+			existObj: &corev1.Secret{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      hypershiftBucketSecretName,
+					Namespace: "test1",
+				},
+				Data: map[string][]byte{
+					"bucket": []byte("bucket1"),
+					"region": []byte("region1"),
+				},
+			},
+			hyd:          GetHypershiftDeployment("test", "hyd1", "test1", hydapi.InfraConfigureWithManifest),
+			expectBucket: "bucket1",
+			expectRegion: "region1",
+		},
+		{
+			name: "get info from configmap infra config only",
+			existObj: &corev1.ConfigMap{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      oidcStorageProvider,
+					Namespace: oidcSPNamespace,
+				},
+				Data: map[string]string{
+					"name":   "bucket1",
+					"region": "region1",
+				},
+			},
+			hyd:          GetHypershiftDeployment("test", "hyd1", "", hydapi.InfraConfigureOnly),
+			expectBucket: "bucket1",
+			expectRegion: "region1",
+		},
+		{
+			name: "get info from configmap orphan",
+			existObj: &corev1.ConfigMap{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      oidcStorageProvider,
+					Namespace: oidcSPNamespace,
+				},
+				Data: map[string]string{
+					"name":   "bucket1",
+					"region": "region1",
+				},
+			},
+			hyd:          GetHypershiftDeployment("test", "hyd1", "", hydapi.InfraOverrideDestroy),
+			expectBucket: "bucket1",
+			expectRegion: "region1",
+		},
+		{
+			name:        "get info from secret not found",
+			hyd:         GetHypershiftDeployment("test", "hyd1", "", hydapi.InfraConfigureWithManifest),
+			expectedErr: "not found",
+		},
+		{
+			name:        "get info from configmap not found",
+			hyd:         GetHypershiftDeployment("test", "hyd1", "", hydapi.InfraConfigureOnly),
+			expectedErr: "not found",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ctx := context.Background()
+			r := GetHypershiftDeploymentReconciler()
+
+			if c.existObj != nil {
+				assert.Nil(t, r.Client.Create(ctx, c.existObj, &crclient.CreateOptions{}), "")
+			}
+
+			bucket, region, err := oidcDiscoveryURL(r, c.hyd)
+			if len(c.expectedErr) == 0 {
+				assert.Nil(t, err, "oidc discovery url was successful")
+				assert.Equal(t, c.expectBucket, bucket, "bucket equal")
+				assert.Equal(t, c.expectRegion, region, "region equal")
+			} else {
+				assert.Contains(t, err.Error(), c.expectedErr)
+			}
+		})
+	}
+}

--- a/pkg/controllers/azure_infra.go
+++ b/pkg/controllers/azure_infra.go
@@ -32,7 +32,7 @@ import (
 	hypdeployment "github.com/stolostron/hypershift-deployment-controller/api/v1alpha1"
 )
 
-const CCredsSuffix = "-cloud-credentials"
+const CCredsSuffix = "-cloud-credentials" // #nosec G101
 
 func (r *HypershiftDeploymentReconciler) createAzureInfra(hyd *hypdeployment.HypershiftDeployment, providerSecret *corev1.Secret) (ctrl.Result, error) {
 	oHyd := *hyd.DeepCopy()


### PR DESCRIPTION
Signed-off-by: zhujian <jiazhu@redhat.com>
issue reference: https://github.com/stolostron/backlog/issues/20897

1. rename several go files, replace `-` with `_`
2. when the override is manifest work, get bucket and region from the bucket secret.
3. add tests for the oidcDiscoveryURL func