### PR TITLE
Set default values for hosted cluster

### DIFF
--- a/pkg/controllers/default_resources.go
+++ b/pkg/controllers/default_resources.go
@@ -136,6 +136,13 @@ func ScaffoldAWSHostedClusterSpec(hyd *hypdeployment.HypershiftDeployment, infra
 		KubeCloudControllerCreds:  corev1.LocalObjectReference{Name: hyd.Name + "-cloud-ctrl-creds"},
 		NodePoolManagementCreds:   corev1.LocalObjectReference{Name: hyd.Name + "-node-mgmt-creds"},
 		EndpointAccess:            hyp.Public,
+		ResourceTags: []hyp.AWSResourceTag{
+			//set the resource tags to prevent the work always updating the hostedcluster resource on the hosting cluster.
+			{
+				Key:   "kubernetes.io/cluster/" + hyd.Spec.HostedClusterSpec.InfraID,
+				Value: "owned",
+			},
+		},
 	}
 	hyd.Spec.HostedClusterSpec.Platform.AWS = ap
 	hyd.Spec.HostedClusterSpec.Platform.AWS.CloudProviderConfig = scaffoldCloudProviderConfig(infraOut)


### PR DESCRIPTION
Signed-off-by: zhujian <jiazhu@redhat.com>
Issue reference: https://github.com/stolostron/backlog/issues/21260#issuecomment-1085994244

Compare the hostedCluster in our manifestwork and the real hostedcluster in the hosting cluster, we found there are 3 different fields in the spec.
- clusterID
- olmCatalogPlacement
- aws.resourceTags

This PR set these field before scolffold the ManifestWork, so it will prevent the work always updating the hostedcluster resource on the hosting cluster.

<img width="1552" alt="image" src="https://user-images.githubusercontent.com/36154065/161377159-1291341c-cb47-4a8b-8837-44e885431ae3.png">


After this fix, the machineset will become what we expected:
```
╰─$ oc get machinesets.cluster.x-k8s.io -n clusters-hypershift-test
NAME                                                    CLUSTER                 REPLICAS   READY   AVAILABLE   AGE   VERSION
hypershift-test-4p-177df44b-hypershift-test-5c57bc85c   hypershift-test-4pjtf   2          2       2           12m   4.10.8
```