### PR TITLE
Remove oidc service def. Not required

### DIFF
--- a/pkg/controllers/default_resources.go
+++ b/pkg/controllers/default_resources.go
@@ -188,7 +188,6 @@ func scaffoldHostedClusterSpec(hyd *hypdeployment.HypershiftDeployment) {
 				Services: []hyp.ServicePublishingStrategyMapping{
 					spsMap(hyp.APIServer, hyp.LoadBalancer),
 					spsMap(hyp.OAuthServer, hyp.Route),
-					spsMap(hyp.OIDC, hyp.S3),
 					spsMap(hyp.Konnectivity, hyp.Route),
 					spsMap(hyp.Ignition, hyp.Route),
 				},


### PR DESCRIPTION
Signed-off-by: Joshua Packer <jpacker@redhat.com>

This is no longer required.
Epic reference: https://github.com/stolostron/backlog/issues/18224