### PR TITLE
Add vendor and cloud label for managed cluster

### DIFF
--- a/pkg/controllers/autoimport/autoimport_controller.go
+++ b/pkg/controllers/autoimport/autoimport_controller.go
@@ -203,6 +203,11 @@ func ensureManagedCluster(r *Reconciler, hydNamespaceName types.NamespacedName,
 		mc.Name = managedClusterName
 		mc.Spec.HubAcceptsClient = true
 
+		mc.ObjectMeta.Labels = map[string]string{
+			"vendor": "OpenShift",   // This is always true
+			"cloud":  "auto-detect", // Work addon will use this to detect cloud provider, like: GCP,AWS
+		}
+
 		mc.ObjectMeta.Annotations = map[string]string{
 			klusterletDeployMode: "Hosted",
 			hostingClusterName:   managementClusterName,

--- a/pkg/controllers/autoimport/autoimport_controller_test.go
+++ b/pkg/controllers/autoimport/autoimport_controller_test.go
@@ -169,6 +169,10 @@ func TestReconcileCreate(t *testing.T) {
 					mc.Annotations[klusterletDeployMode], "assert hosted mode annotation value")
 				assert.Equal(t, helper.GetHostingCluster(hyd),
 					mc.Annotations[hostingClusterName], "assert management cluster annotation value")
+				assert.Equal(t, "OpenShift",
+					mc.Labels["vendor"], "assert management cluster vendor label")
+				assert.Equal(t, "auto-detect",
+					mc.Labels["cloud"], "assert management cluster cloud label")
 
 				assertAnnoNotContainCreateMC(t, ctx, client)
 			},


### PR DESCRIPTION
Signed-off-by: zhujian <jiazhu@redhat.com>
issue reference: https://github.com/stolostron/backlog/issues/21472


After this is merged, the managed cluster will look like:
```
apiVersion: cluster.open-cluster-management.io/v1
kind: ManagedCluster
metadata:
  annotations:
    cluster.open-cluster-management.io/hypershiftdeployment: zjtest/hypershift-ns
    cluster.open-cluster-management.io/provisioner: hypershift-ns.zjtest.HypershiftDeployment.cluster.open-cluster-management.io
    import.open-cluster-management.io/hosting-cluster-name: local-cluster
    import.open-cluster-management.io/klusterlet-deploy-mode: Hosted
    open-cluster-management/created-via: other
  creationTimestamp: "2022-04-07T03:26:56Z"
  finalizers:
  - managedcluster-import-controller.open-cluster-management.io/cleanup
  - cluster.open-cluster-management.io/api-resource-cleanup
  - managedcluster-import-controller.open-cluster-management.io/manifestwork-cleanup
  - managedclusterinfo.finalizers.open-cluster-management.io
  - open-cluster-management.io/managedclusterrole
  generation: 4
  labels:
    cloud: Amazon
    cluster.open-cluster-management.io/clusterset: default
    clusterID: ad21406c-3768-46fc-962f-1df63f813072
    feature.open-cluster-management.io/addon-cert-policy-controller: available
    feature.open-cluster-management.io/addon-config-policy-controller: available
    feature.open-cluster-management.io/addon-governance-policy-framework: available
    feature.open-cluster-management.io/addon-iam-policy-controller: available
    feature.open-cluster-management.io/addon-work-manager: available
    name: hypershift-ns-q8cwh
    openshiftVersion: 4.10.9
    vendor: OpenShift
```