### PR TITLE
Add scripts to test sd case

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,17 @@ REPO ?= "quay.io/stolostron/"
 # Image URL to use all building/pushing image targets
 IMG ?= $(REPO)hypershift-deployment-controller:latest
 
+KUBECONFIG ?= ${HOME}/.kube/config
+S3_CREDS ?= ${HOME}/.aws/credentials
+BUCKET_REGION ?= ""
+BUCKET_NAME ?= ""
+CLOUD_PROVIDER_SECRET_NAME ?= ""
+CLOUD_PROVIDER_SECRET_NAMESPACE ?= "default"
+INFRA_REGION ?= "us-east-1"
+HYPERSHIFT_DEPLOYMENT_NAME ?= "hypershift-test"
+
+KUBECTL ?= kubectl --kubeconfig=$(KUBECONFIG)
+
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.22
 
@@ -135,3 +146,18 @@ GOBIN=$(PROJECT_DIR)/bin go get $(2) ;\
 rm -rf $$TMP_DIR ;\
 }
 endef
+
+.PHONY: install-hypershift-addon
+install-hypershift-addon:
+	S3_CREDS=${S3_CREDS} BUCKET_REGION=${BUCKET_REGION} BUCKET_NAME=${BUCKET_NAME} samples/quickstart/start.sh
+
+.PHONY: create-a-hosted-cluster
+create-a-hosted-cluster:
+	CLOUD_PROVIDER_SECRET_NAMESPACE=${CLOUD_PROVIDER_SECRET_NAMESPACE} CLOUD_PROVIDER_SECRET_NAME=${CLOUD_PROVIDER_SECRET_NAME} INFRA_REGION=${INFRA_REGION} HYPERSHIFT_DEPLOYMENT_NAME=${HYPERSHIFT_DEPLOYMENT_NAME} samples/quickstart/create-aws-hosted-cluster.sh
+
+.PHONY: create-a-policy
+create-a-policy:
+	HYPERSHIFT_DEPLOYMENT_NAME=${HYPERSHIFT_DEPLOYMENT_NAME} samples/quickstart/create-policy.sh
+
+.PHONY: test-sd
+test-sd: install-hypershift-addon create-a-hosted-cluster create-a-policy

--- a/samples/quickstart/create-aws-hosted-cluster.sh
+++ b/samples/quickstart/create-aws-hosted-cluster.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+# Copyright 2022.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+if [ "${CLOUD_PROVIDER_SECRET_NAMESPACE}" == "" ]; then
+  printf "\n**WARNING** No CLOUD_PROVIDER_SECRET_NAMESPACE found, export it and try again\n"
+  printf "Enter the cloud provider secret namespace\n"
+  read -r CLOUD_PROVIDER_SECRET_NAMESPACE
+  if [ "${CLOUD_PROVIDER_SECRET_NAMESPACE}" == "" ]; then
+    echo "No CLOUD_PROVIDER_SECRET_NAMESPACE provided"
+    exit 1
+  fi
+fi
+
+if [ "${CLOUD_PROVIDER_SECRET_NAME}" == "" ]; then
+  printf "\n**WARNING** No CLOUD_PROVIDER_SECRET_NAME found, export it and try again\n"
+  printf "Enter the cloud provider secret name\n"
+  read -r CLOUD_PROVIDER_SECRET_NAME
+  if [ "${CLOUD_PROVIDER_SECRET_NAME}" == "" ]; then
+    echo "No CLOUD_PROVIDER_SECRET_NAME provided"
+    exit 1
+  fi
+fi
+
+if [ "${INFRA_REGION}" == "" ]; then
+  printf "\n**WARNING** No INFRA_REGION found, export it and try again\n"
+  printf "Enter the infrastructure region\n"
+  read -r INFRA_REGION
+  if [ "${INFRA_REGION}" == "" ]; then
+    echo "No INFRA_REGION provided"
+    exit 1
+  fi
+fi
+
+
+
+if [ "${HYPERSHIFT_DEPLOYMENT_NAME}" == "" ]; then
+  printf "\n**INFO** No HYPERSHIFT_DEPLOYMENT_NAME found, use default value \"hypershift-test\"\n"
+  HYPERSHIFT_DEPLOYMENT_NAME="hypershift-test"
+fi
+
+printf 'Cloud provider secret namespace: %s\n' "${CLOUD_PROVIDER_SECRET_NAMESPACE}"
+printf 'Cloud provider secret name     : %s\n' "${CLOUD_PROVIDER_SECRET_NAME}"
+printf 'Infrastructure region          : %s\n' "${INFRA_REGION}"
+printf 'Hypershift deployment name     : %s\n' "${HYPERSHIFT_DEPLOYMENT_NAME}"
+
+oc get secret -n "${CLOUD_PROVIDER_SECRET_NAMESPACE}" "${CLOUD_PROVIDER_SECRET_NAME}"
+if [ $? -ne 0 ]; then
+  printf "Secret %s/%s not found\n" "${CLOUD_PROVIDER_SECRET_NAMESPACE}" "${CLOUD_PROVIDER_SECRET_NAME}"
+  printf "You can create the secret via https://console-openshift-console.apps.<your-openshift-domain>/multicloud/credentials"
+  exit 1
+fi
+
+
+oc apply -f - <<EOF
+apiVersion: cluster.open-cluster-management.io/v1alpha1
+kind: HypershiftDeployment
+metadata:
+  name: ${HYPERSHIFT_DEPLOYMENT_NAME}
+  namespace: ${CLOUD_PROVIDER_SECRET_NAMESPACE}
+spec:
+  hostingCluster: local-cluster
+  hostingNamespace: clusters
+  infrastructure:
+    cloudProvider:
+      name: ${CLOUD_PROVIDER_SECRET_NAME}
+    configure: True
+    platform:
+      aws:
+        region: ${INFRA_REGION}
+EOF
+
+echo "wait for managed cluster addon hypershift addon to be available ..."
+oc wait --for=condition=Available managedclusteraddon/hypershift-addon -n local-cluster --timeout=600s
+if [ $? -ne 0 ]
+then
+  echo "hypershift addon installation failed"
+  exit 1
+else
+  echo "hypershift addon installed successfully, now you can provision a hosted control plane cluster by HypershiftDeployment"
+fi
+
+managed_cluster_name=$(oc get managedcluster | grep ${HYPERSHIFT_DEPLOYMENT_NAME} | awk '{print $1}')
+echo "managed_cluster_name: ${managed_cluster_name}"
+oc get managedclusteraddon -n ${managed_cluster_name}
+
+echo "wait for the managed cluster to be available"
+oc wait --for=condition=ManagedClusterConditionAvailable managedcluster/${managed_cluster_name} --timeout=600s
+if [ $? -ne 0 ]
+then
+  echo "timeout for waiting managed cluster ${managed_cluster_name} to be available"
+  exit 1
+else
+  echo "managed cluster ${managed_cluster_name} is available now"
+fi
+
+oc get managedcluster ${managed_cluster_name}
+oc get pod -n klusterlet-${managed_cluster_name}
+
+oc get managedclusteraddon -n ${managed_cluster_name}
+
+echo "wait for the work manager addon to be available"
+oc wait --for=condition=Available managedclusteraddon/work-manager -n ${managed_cluster_name} --timeout=600s
+if [ $? -ne 0 ]
+then
+  echo "timeout for waiting managed cluster ${managed_cluster_name} work manager addon to be available"
+  exit 1
+else
+  echo "managed cluster ${managed_cluster_name} work manager addon is available now"
+fi
+
+oc get managedclusteraddon -n ${managed_cluster_name}
+oc get managedcluster ${managed_cluster_name}
+
+hosted_cluster_console_url=$(oc get managedcluster ${managed_cluster_name} -ojsonpath='{.status.clusterClaims[?(@.name=="consoleurl.cluster.open-cluster-management.io")].value}')
+echo "hosted cluster console url: ${hosted_cluster_console_url}"

--- a/samples/quickstart/create-policy.sh
+++ b/samples/quickstart/create-policy.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+# Copyright 2022.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+function wait_policy_result() {
+  set +e
+  for((i=0;i<30;i++));
+  do
+    result=$(oc -n $1 get policy $2 -ojsonpath="{.status.compliant}")
+    if [[ -n $result ]]; then
+      break
+    fi
+    echo "sleep 1 second to wait policy $1/$2 to be finished: $i"
+    sleep 1
+  done
+  set -e
+}
+
+if [ "${HYPERSHIFT_DEPLOYMENT_NAME}" == "" ]; then
+  printf "\n**INFO** No HYPERSHIFT_DEPLOYMENT_NAME found, use default value \"hypershift-test\"\n"
+  HYPERSHIFT_DEPLOYMENT_NAME="hypershift-test"
+fi
+
+printf 'Hypershift deployment name     : %s\n' "${HYPERSHIFT_DEPLOYMENT_NAME}"
+
+managed_cluster_name=$(oc get managedcluster | grep ${HYPERSHIFT_DEPLOYMENT_NAME} | awk '{print $1}')
+echo "managed_cluster_name: ${managed_cluster_name}"
+
+oc apply -f - <<EOF
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: policy-namespace
+  annotations:
+    policy.open-cluster-management.io/standards: NIST SP 800-53
+    policy.open-cluster-management.io/categories: CM Configuration Management
+    policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+spec:
+  remediationAction: inform
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: policy-namespace-example
+        spec:
+          remediationAction: inform # the policy-template spec.remediationAction is overridden by the preceding parameter value for spec.remediationAction.
+          severity: low
+          namespaceSelector:
+            exclude: ["kube-*"]
+            include: ["default"]
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                kind: Namespace # must have namespace 'prod'
+                apiVersion: v1
+                metadata:
+                  name: prod
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: binding-policy-namespace
+placementRef:
+  name: placement-policy-namespace
+  kind: PlacementRule
+  apiGroup: apps.open-cluster-management.io
+subjects:
+- name: policy-namespace
+  kind: Policy
+  apiGroup: policy.open-cluster-management.io
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: placement-policy-namespace
+spec:
+  clusterConditions:
+  - status: "True"
+    type: ManagedClusterConditionAvailable
+  clusterSelector:
+    # matchExpressions:
+    #   - {key: environment, operator: In, values: ["dev"]}
+    matchExpressions:
+      - key: name
+        operator: In
+        values:
+          - ${managed_cluster_name}
+EOF
+
+
+
+echo -n "Wait for the policy result..."
+wait_policy_result default policy-namespace
+
+policy_result=$(oc get policy policy-namespace -ojsonpath="{.status.status[?(@.clustername==\"${managed_cluster_name}\")].compliant}")
+if [ ${policy_result} != "NonCompliant" ]
+then
+  echo "expect result \"policy_result\", but got \"${policy_result}\""
+else
+  echo "policy namespace applied to the hosted cluster ${managed_cluster_name} successfully, policy result: \"${policy_result}\""
+fi


### PR DESCRIPTION
1. Distinguish the name of mce CR in ACM and MCE
2. Import local cluster by label local-cluster true

Signed-off-by: zhujian <jiazhu@redhat.com>

Add test script for the sd case

This PR provides a script for the QE team to verify the sd case:
```
S3_CREDS=/root/.aws/credentials BUCKET_REGION=us-east-1 BUCKET_NAME=acm-test-hypershift CLOUD_PROVIDER_SECRET_NAME=test-aws-secret CLOUD_PROVIDER_SECRET_NAMESPACE=default INFRA_REGION=us-east-1 HYPERSHIFT_DEPLOYMENT_NAME=hypershift-test-sd make test-sd
```

Signed-off-by: zhujian <jiazhu@redhat.com>

issue reference: https://github.com/stolostron/backlog/issues/20453#issuecomment-1085385301