### PR TITLE
Bump golang to 1.18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.ci.openshift.org/stolostron/builder:go1.17-linux as builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.18-linux as builder
 
 WORKDIR /go/src/github.com/stolostron/hypershift-deployment-controller
 # Copy the Go Modules manifests


### PR DESCRIPTION
Signed-off-by: zhujian <jiazhu@redhat.com>

<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* Bump golang to 1.18

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  The upstream hypershift project is using golang 1.18, it is better to upgrade the base image for the hypershift-deployment-controller to 1.18

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://github.com/stolostron/backlog/issues/22238

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant -->
## Test API/Unit - Success
```script
ok  	github.com/stolostron/hypershift-deployment-controller/pkg/controllers	22.550s	coverage: 77.7% of statements
ok  	github.com/stolostron/hypershift-deployment-controller/pkg/controllers/autoimport	2.202s	coverage: 61.5% of statements
```

