### PR TITLE
Set infra and iam status condition to NA for configure=F

### DIFF
--- a/pkg/controllers/hypershiftdeployment_controller.go
+++ b/pkg/controllers/hypershiftdeployment_controller.go
@@ -153,6 +153,10 @@ func (r *HypershiftDeploymentReconciler) Reconcile(ctx context.Context, req ctrl
 				return requeue, err
 			}
 		}
+	} else {
+		_ = r.updateStatusConditionsOnChange(&hyd, hypdeployment.PlatformIAMConfigured, metav1.ConditionFalse, "Platform IAM configuration is not applicable for Spec.Infrastructure.Configure=False", hypdeployment.NotApplicableReason)
+
+		_ = r.updateStatusConditionsOnChange(&hyd, hypdeployment.PlatformConfigured, metav1.ConditionFalse, "Platform configuration is not applicable for Spec.Infrastructure.Configure=False", hypdeployment.NotApplicableReason)
 	}
 
 	// Just build the infrastruction platform, do not deploy HostedCluster and NodePool(s)

--- a/pkg/controllers/hypershiftdeployment_controller_test.go
+++ b/pkg/controllers/hypershiftdeployment_controller_test.go
@@ -466,6 +466,14 @@ func TestConfigureFalseWithManifestWorkWithObjectRef(t *testing.T) {
 	t.Log("Check infraID label")
 	assert.NotEmpty(t, resultHD.Labels, "The infra-id should always be written to the label hypershift.openshift.io/infra-id")
 	assert.Equal(t, resultHD.Labels[constant.InfraLabelName], testHD.Spec.InfraID, "The infra-id must contain the cluster name")
+
+	// Check PlatformConfigure and PlatformIAMConfigure status conditions
+	c := meta.FindStatusCondition(resultHD.Status.Conditions, string(hyd.PlatformConfigured))
+	assert.Equal(t, hypdeployment.NotApplicableReason, c.Reason, "is equal when Platform configure status condition is correct")
+
+	c = meta.FindStatusCondition(resultHD.Status.Conditions, string(hyd.PlatformIAMConfigured))
+	assert.Equal(t, hypdeployment.NotApplicableReason, c.Reason, "is equal when Platform IAM configure status condition is correct")
+
 }
 
 func getSecret(secretName string) *corev1.Secret {

--- a/pkg/controllers/manifestwork.go
+++ b/pkg/controllers/manifestwork.go
@@ -651,7 +651,8 @@ func getManifestPayloadSecretByName(manifests *[]workv1.Manifest, secretName str
 				}
 				return secret, nil
 			}
-		} else if v.Object != nil && v.Object.GetObjectKind().GroupVersionKind().Kind == "Secret" {
+		} else if v.Object != nil && v.Object.GetObjectKind().GroupVersionKind().Kind == "Secret" &&
+			v.Object.(*corev1.Secret).Name == secretName {
 			return v.Object.(*corev1.Secret), nil
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Philip Wu <phwu@redhat.com>

<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* The INFRA and IAM status conditions are not applicable for infrastrastructure.configure=F. The reason for the status conditions should reflect this and should have the value "NA".

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  Currently,  INFRA and IAM status conditions for infrastrastructure.configure=F has the value "beingConfigured".

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
*  https://issues.redhat.com/browse/ACM-1328

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant -->
## Test API/Unit - Success
```script
ok  	github.com/stolostron/hypershift-deployment-controller/pkg/controllers	4.276s	coverage: 77.8% of statements
ok  	github.com/stolostron/hypershift-deployment-controller/pkg/controllers/autoimport	0.714s	coverage: 61.5% of statements
```

