### PR TITLE
Verify customized flow for AWS.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ If there is problem, looking at the `HypershiftDeployment.Status.Conditions[].me
 ## Customizing your hosted resource
 You can customize the values for HostedCluster (bring your own) or in combination with `Spec.Infrastructure.Configure: True`.
 
+The following shows a customized version of `hypershiftDeployment` where you can tweak the control plane as well as the Worker nodes found in the `nodePools`.
+
+[./samples/aws.cluster.custom.yaml](samples/aws.cluster.custom.yaml)
+
 ## Bring your own infrastructure
 If `Spec.Infrastructure.Configure: False` you must provide a complete `Spec.HostedClusterSpec` and `Spec.NodePools` definition.  Otherwise the two resources will not successfully complete and you will not get a Hypershift cluster.
 

--- a/api/v1alpha1/hypershiftdeployment_types.go
+++ b/api/v1alpha1/hypershiftdeployment_types.go
@@ -109,7 +109,6 @@ type HypershiftDeploymentSpec struct {
 	//If not specified, the controller will flag an error condition.
 	//The HostingCluster would be the management cluster of the hostedcluster and nodepool generated
 	//by the hypershiftDeployment
-	// +optional
 	HostingCluster string `json:"hostingCluster"`
 
 	// HostedCluster that will be applied to the ManagementCluster by ACM, if omitted, it will be generated

--- a/config/crd/cluster.open-cluster-management.io_hypershiftdeployments.yaml
+++ b/config/crd/cluster.open-cluster-management.io_hypershiftdeployments.yaml
@@ -1943,6 +1943,7 @@ spec:
                 - DELETE-HOSTING-NAMESPACE
                 type: string
             required:
+            - hostingCluster
             - infrastructure
             type: object
           status:

--- a/pkg/controllers/hypershiftdeployment_controller.go
+++ b/pkg/controllers/hypershiftdeployment_controller.go
@@ -144,12 +144,12 @@ func (r *HypershiftDeploymentReconciler) Reconcile(ctx context.Context, req ctrl
 		}
 
 		if hyd.Spec.Infrastructure.Platform.AWS != nil {
-			if requeue, err := r.createAWSInfra(&hyd, &providerSecret); err != nil {
+			if requeue, err := r.createAWSInfra(&hyd, &providerSecret); err != nil || requeue.Requeue {
 				return requeue, err
 			}
 		}
 		if hyd.Spec.Infrastructure.Platform.Azure != nil {
-			if requeue, err := r.createAzureInfra(&hyd, &providerSecret); err != nil {
+			if requeue, err := r.createAzureInfra(&hyd, &providerSecret); err != nil || requeue.Requeue {
 				return requeue, err
 			}
 		}
@@ -350,12 +350,12 @@ func (r *HypershiftDeploymentReconciler) destroyHypershift(hyd *hypdeployment.Hy
 		hyd.Spec.Infrastructure.Configure {
 		// Infrastructure is the last step
 		if hyd.Spec.Infrastructure.Platform.AWS != nil {
-			if result, err := r.destroyAWSInfrastructure(hyd, providerSecret); err != nil {
+			if result, err := r.destroyAWSInfrastructure(hyd, providerSecret); err != nil || result.Requeue {
 				return result, nil // destroyAWSInfrastructure uses requeue times, switch to nil
 			}
 		}
 		if hyd.Spec.Infrastructure.Platform.Azure != nil {
-			if result, err := r.destroyAzureInfrastructure(hyd, providerSecret); err != nil {
+			if result, err := r.destroyAzureInfrastructure(hyd, providerSecret); err != nil || result.Requeue {
 				return result, nil // destroyAzureInfrastructure uses requeue times, switch to nil
 			}
 		}

--- a/samples/aws.cluster.custom.yaml
+++ b/samples/aws.cluster.custom.yaml
@@ -1,0 +1,58 @@
+apiVersion: cluster.open-cluster-management.io/v1alpha1
+kind: HypershiftDeployment
+metadata:
+  name: aws-custom-sample
+spec:
+  hostingCluster: local-cluster
+  hostingNamespace: clusters
+  infrastructure:
+    cloudProvider:
+      name:  my-cloud-provider-secret
+    configure: True                   # infrastructure in the provider will be configured
+    platform:
+      aws:
+        region: us-west-1
+  hostedClusterSpec:
+    etcd:
+      managed:
+        storage:
+          persistentVolume:
+            size: 4Gi
+          type: PersistentVolume
+      managementType: Managed
+    controllerAvailabilityPolicy: SingleReplica
+    #controllerAvailabilityPolicy: HighlyAvailable
+    release:
+      image: quay.io/openshift-release-dev/ocp-release:4.10.15-x86_64
+    networking:
+      networkType: OpenShiftSDN
+      machineCIDR: ""           # Can be left empty, when configure: true
+      podCIDR: ""               # Can be left empty, when configure: true
+      serviceCIDR: ""           # Can be left empty, when configure: true
+    platform:
+      type: AWS
+    pullSecret: {}  # Can be left empty, when configure: true
+    sshKey: {}      # Can be left empty, when configure: true
+    services: []    # Can be left empty, when configure: true
+  nodePools:
+  - name: aws-custom-sample
+    spec:
+      clusterName: aws-custom-sample
+      management:
+        autoRepair: false
+        replace:
+          rollingUpdate:
+            maxSurge: 1
+            maxUnavailable: 0
+          strategy: RollingUpdate
+        upgradeType: Replace
+      nodeCount: 2
+      platform:
+        aws:
+          instanceType: t3.large
+          rootVolume:
+            size: 35
+            type: gp3
+        type: AWS
+      release:
+        image: quay.io/openshift-release-dev/ocp-release:4.10.15-x86_64

--- a/samples/aws.cluster.open-cluster-management.io_v1alpha1_hypershiftdeployment.yaml
+++ b/samples/aws.cluster.open-cluster-management.io_v1alpha1_hypershiftdeployment.yaml
@@ -3,6 +3,8 @@ kind: HypershiftDeployment
 metadata:
   name: aws-sample
 spec:
+  hostingCluster: local-cluster
+  hostingNamespace: clusters
   infrastructure:
     cloudProvider:
       name: my-cloud-provider-secret


### PR DESCRIPTION
Signed-off-by: Joshua Packer <jpacker@redhat.com>

<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
1. Support changing up the AvailabilityPolicy
2. Release.Image
3. NodePool.Spec.Platform.AWS for the node's AMI information
4. NodePool release image.
5. Readme update with a reference to this YAML
6. Fixed some bugs in this flow
7. Fixed a poor condition message when spec.hostingCluster is missing
8. Fixed a bug where we exited during a destroy early, orphaning resources

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  Customizing the HypershiftCluster is a requirement of the release.

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-1372

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant -->
## Test API/Unit - Success
```script
?       github.com/stolostron/hypershift-deployment-controller/api/v1alpha1     [no test files]
?       github.com/stolostron/hypershift-deployment-controller/pkg      [no test files]
?       github.com/stolostron/hypershift-deployment-controller/pkg/constant     [no test files]
ok      github.com/stolostron/hypershift-deployment-controller/pkg/controllers  2.482s  coverage: 77.0% of statements
ok      github.com/stolostron/hypershift-deployment-controller/pkg/controllers/autoimport       0.017s  coverage: 61.5% of statements
?       github.com/stolostron/hypershift-deployment-controller/pkg/helper       [no test files]
ok      github.com/stolostron/hypershift-deployment-controller/test/integration 20.874s coverage: [no statements]
```

