### PR TITLE
Use replicas to config the desired number of nodes the pool should maintain

### DIFF
--- a/pkg/controllers/default_resources.go
+++ b/pkg/controllers/default_resources.go
@@ -304,7 +304,7 @@ func ScaffoldAWSNodePoolSpec(hyd *hypdeployment.HypershiftDeployment, infraOut *
 
 func ScaffoldNodePoolSpec(hyd *hypdeployment.HypershiftDeployment) {
 
-	nodeCount := int32(2)
+	replicas := int32(2)
 
 	if len(hyd.Spec.NodePools) == 0 {
 		hyd.Spec.NodePools = []*hypdeployment.HypershiftNodePools{
@@ -323,7 +323,7 @@ func ScaffoldNodePoolSpec(hyd *hypdeployment.HypershiftDeployment) {
 						},
 						UpgradeType: hyp.UpgradeTypeReplace,
 					},
-					NodeCount: &nodeCount,
+					Replicas: &replicas,
 					Platform: hyp.NodePoolPlatform{
 						Type: hyp.NonePlatform,
 					},

--- a/test/integration/manifest_test.go
+++ b/test/integration/manifest_test.go
@@ -49,7 +49,7 @@ var _ = ginkgo.Describe("Manifest Work", func() {
 			},
 		}
 
-		nodeCount := int32(2)
+		replicas := int32(2)
 		np = &hyp.NodePool{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-nodepool",
@@ -68,7 +68,7 @@ var _ = ginkgo.Describe("Manifest Work", func() {
 					},
 					UpgradeType: hyp.UpgradeTypeReplace,
 				},
-				NodeCount: &nodeCount,
+				Replicas: &replicas,
 				Platform: hyp.NodePoolPlatform{
 					Type: hyp.NonePlatform,
 				},


### PR DESCRIPTION
Signed-off-by: zhujian <jiazhu@redhat.com>

<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* Use replicas to config the desired number of nodes the pool should maintain

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  The [hypershift controller](https://github.com/openshift/hypershift/blob/ad143ad73524418d92c40a0501a4040cde282f54/hypershift-operator/controllers/nodepool/nodepool_controller.go#L203-L208) will set the `nodepool.spec.replicas` to value `nodepool.spec.nodecount` when it is empty, in our case, the hypershift deployment controller set the default nodecount to 2, but not set the replica, so the hypershift-operator will update it to 2, but we use manifestwork to sync the nodepool resource to the hosting cluster periodically, so every time the hypershift operator set the replica to 2, the manifestwork will set it back to 0, which causes the `generation` of the nodepool always changing.

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://github.com/stolostron/backlog/issues/22689
Related PR: https://github.com/stolostron/backplane-operator/pull/198

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant -->
## Test API/Unit - Success
```script
?   	github.com/stolostron/hypershift-deployment-controller/api/v1alpha1	[no test files]
?   	github.com/stolostron/hypershift-deployment-controller/pkg	[no test files]
?   	github.com/stolostron/hypershift-deployment-controller/pkg/constant	[no test files]
ok  	github.com/stolostron/hypershift-deployment-controller/pkg/controllers	0.854s	coverage: 77.9% of statements
ok  	github.com/stolostron/hypershift-deployment-controller/pkg/controllers/autoimport	0.038s	coverage: 61.5% of statements
?   	github.com/stolostron/hypershift-deployment-controller/pkg/helper	[no test files]
ok  	github.com/stolostron/hypershift-deployment-controller/test/integration	21.854s	coverage: [no statements]
```

