### PR TITLE
ObjectRef build support:

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ help: ## Display this help.
 ##@ Development
 
 .PHONY: manifests
-manifests: controller-gen ## Generate ClusterRole and CustomResourceDefinition objects. rm -f config/crd/*.yaml
+manifests: controller-gen get-hypershift-crds## Generate ClusterRole and CustomResourceDefinition objects. rm -f config/crd/*.yaml
 	$(CONTROLLER_GEN) rbac:roleName=hypershfit-deployment-controller crd paths="./..." output:crd:artifacts:config=config/crd
 
 .PHONY: generate
@@ -172,3 +172,9 @@ create-a-policy:
 
 .PHONY: test-sd
 test-sd: install-hypershift-addon create-a-hosted-cluster create-a-policy
+
+.PHONY: get-hypershift-crds
+get-hypershift-crds:
+	export COMMIT_SHA=`cat go.mod | grep github.com/openshift/hypershift | sed -En 's/.* v.*-//p'`; \
+	curl https://raw.githubusercontent.com/openshift/hypershift/${COMMIT_SHA}/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml > ./config/crd/hypershift.openshift.io_hostedclusters.yaml; \
+	curl https://raw.githubusercontent.com/openshift/hypershift/${COMMIT_SHA}/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml > ./config/crd/hypershift.openshift.io_nodepools.yaml; \

--- a/Makefile
+++ b/Makefile
@@ -173,8 +173,9 @@ create-a-policy:
 .PHONY: test-sd
 test-sd: install-hypershift-addon create-a-hosted-cluster create-a-policy
 
+COMMIT_SHA := $(shell cat go.mod | grep github.com/openshift/hypershift | sed -En 's/.* v.*-//p')
 .PHONY: get-hypershift-crds
 get-hypershift-crds:
-	export COMMIT_SHA=`cat go.mod | grep github.com/openshift/hypershift | sed -En 's/.* v.*-//p'`; \
-	curl https://raw.githubusercontent.com/openshift/hypershift/${COMMIT_SHA}/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml > ./config/crd/hypershift.openshift.io_hostedclusters.yaml; \
-	curl https://raw.githubusercontent.com/openshift/hypershift/${COMMIT_SHA}/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml > ./config/crd/hypershift.openshift.io_nodepools.yaml; \
+	@echo Using SHA ${COMMIT_SHA}; \
+	curl https://raw.githubusercontent.com/openshift/hypershift/${COMMIT_SHA}/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml > ./config/crd/hypershift.openshift.io_hostedclusters.yaml;
+	curl https://raw.githubusercontent.com/openshift/hypershift/${COMMIT_SHA}/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml > ./config/crd/hypershift.openshift.io_nodepools.yaml;

--- a/config/crd/hypershift.openshift.io_hostedclusters.yaml
+++ b/config/crd/hypershift.openshift.io_hostedclusters.yaml
@@ -1,0 +1,1346 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.5.0
+  creationTimestamp: null
+  name: hostedclusters.hypershift.openshift.io
+spec:
+  group: hypershift.openshift.io
+  names:
+    kind: HostedCluster
+    listKind: HostedClusterList
+    plural: hostedclusters
+    shortNames:
+    - hc
+    - hcs
+    singular: hostedcluster
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Version
+      jsonPath: .status.version.history[?(@.state=="Completed")].version
+      name: Version
+      type: string
+    - description: KubeConfig Secret
+      jsonPath: .status.kubeconfig.name
+      name: KubeConfig
+      type: string
+    - description: Progress
+      jsonPath: .status.version.history[?(@.state!="")].state
+      name: Progress
+      type: string
+    - description: Available
+      jsonPath: .status.conditions[?(@.type=="Available")].status
+      name: Available
+      type: string
+    - description: Reason
+      jsonPath: .status.conditions[?(@.type=="Available")].reason
+      name: Reason
+      type: string
+    - description: Message
+      jsonPath: .status.conditions[?(@.type=="Available")].message
+      name: Message
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: HostedCluster is the primary representation of a HyperShift cluster
+          and encapsulates the control plane and common data plane configuration.
+          Creating a HostedCluster results in a fully functional OpenShift control
+          plane with no attached nodes. To support workloads (e.g. pods), a HostedCluster
+          may have one or more associated NodePool resources.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec is the desired behavior of the HostedCluster.
+            properties:
+              additionalTrustBundle:
+                description: AdditionalTrustBundle is a reference to a ConfigMap containing
+                  a PEM-encoded X.509 certificate bundle that will be added to the
+                  hosted controlplane and nodes
+                properties:
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                    type: string
+                type: object
+              auditWebhook:
+                description: "AuditWebhook contains metadata for configuring an audit
+                  webhook endpoint for a cluster to process cluster audit events.
+                  It references a secret that contains the webhook information for
+                  the audit webhook endpoint. It is a secret because if the endpoint
+                  has mTLS the kubeconfig will contain client keys. The kubeconfig
+                  needs to be stored in the secret with a secret key name that corresponds
+                  to the constant AuditWebhookKubeconfigKey. \n This field is currently
+                  only supported on the IBMCloud platform."
+                properties:
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                    type: string
+                type: object
+              autoscaling:
+                description: Autoscaling specifies auto-scaling behavior that applies
+                  to all NodePools associated with the control plane.
+                properties:
+                  maxNodeProvisionTime:
+                    description: MaxNodeProvisionTime is the maximum time to wait
+                      for node provisioning before considering the provisioning to
+                      be unsuccessful, expressed as a Go duration string. The default
+                      is 15 minutes.
+                    pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+                    type: string
+                  maxNodesTotal:
+                    description: MaxNodesTotal is the maximum allowable number of
+                      nodes across all NodePools for a HostedCluster. The autoscaler
+                      will not grow the cluster beyond this number.
+                    format: int32
+                    minimum: 0
+                    type: integer
+                  maxPodGracePeriod:
+                    description: MaxPodGracePeriod is the maximum seconds to wait
+                      for graceful pod termination before scaling down a NodePool.
+                      The default is 600 seconds.
+                    format: int32
+                    minimum: 0
+                    type: integer
+                  podPriorityThreshold:
+                    description: "PodPriorityThreshold enables users to schedule \"best-effort\"
+                      pods, which shouldn't trigger autoscaler actions, but only run
+                      when there are spare resources available. The default is -10.
+                      \n See the following for more details: https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-does-cluster-autoscaler-work-with-pod-priority-and-preemption"
+                    format: int32
+                    type: integer
+                type: object
+              clusterID:
+                description: ClusterID uniquely identifies this cluster. This is expected
+                  to be an RFC4122 UUID value (xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+                  in hexadecimal values). As with a Kubernetes metadata.uid, this
+                  ID uniquely identifies this cluster in space and time. This value
+                  identifies the cluster in metrics pushed to telemetry and metrics
+                  produced by the control plane operators. If a value is not specified,
+                  an ID is generated. After initial creation, the value is immutable.
+                pattern: '[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}'
+                type: string
+              configuration:
+                description: Configuration specifies configuration for individual
+                  OCP components in the cluster, represented as embedded resources
+                  that correspond to the openshift configuration API.
+                properties:
+                  configMapRefs:
+                    description: ConfigMapRefs holds references to any configmaps
+                      referenced by configuration entries. Entries can reference the
+                      configmaps using local object references.
+                    items:
+                      description: LocalObjectReference contains enough information
+                        to let you locate the referenced object inside the same namespace.
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                      type: object
+                    type: array
+                  items:
+                    description: Items embeds the serialized configuration resources.
+                    items:
+                      type: object
+                    type: array
+                    x-kubernetes-preserve-unknown-fields: true
+                  secretRefs:
+                    description: SecretRefs holds references to any secrets referenced
+                      by configuration entries. Entries can reference the secrets
+                      using local object references.
+                    items:
+                      description: LocalObjectReference contains enough information
+                        to let you locate the referenced object inside the same namespace.
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              controllerAvailabilityPolicy:
+                default: SingleReplica
+                description: ControllerAvailabilityPolicy specifies the availability
+                  policy applied to critical control plane components. The default
+                  value is SingleReplica.
+                type: string
+              dns:
+                description: DNS specifies DNS configuration for the cluster.
+                properties:
+                  baseDomain:
+                    description: BaseDomain is the base domain of the cluster.
+                    type: string
+                  privateZoneID:
+                    description: PrivateZoneID is the Hosted Zone ID where all the
+                      DNS records that are only available internally to the cluster
+                      exist.
+                    type: string
+                  publicZoneID:
+                    description: PublicZoneID is the Hosted Zone ID where all the
+                      DNS records that are publicly accessible to the internet exist.
+                    type: string
+                required:
+                - baseDomain
+                type: object
+              etcd:
+                default:
+                  managementType: Managed
+                description: Etcd specifies configuration for the control plane etcd
+                  cluster. The default ManagementType is Managed. Once set, the ManagementType
+                  cannot be changed.
+                properties:
+                  managed:
+                    description: Managed specifies the behavior of an etcd cluster
+                      managed by HyperShift.
+                    properties:
+                      storage:
+                        description: Storage specifies how etcd data is persisted.
+                        properties:
+                          persistentVolume:
+                            description: PersistentVolume is the configuration for
+                              PersistentVolume etcd storage. With this implementation,
+                              a PersistentVolume will be allocated for every etcd
+                              member (either 1 or 3 depending on the HostedCluster
+                              control plane availability configuration).
+                            properties:
+                              size:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                default: 4Gi
+                                description: Size is the minimum size of the data
+                                  volume for each etcd member.
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              storageClassName:
+                                description: "StorageClassName is the StorageClass
+                                  of the data volume for each etcd member. \n See
+                                  https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1."
+                                type: string
+                            type: object
+                          type:
+                            description: Type is the kind of persistent storage implementation
+                              to use for etcd.
+                            enum:
+                            - PersistentVolume
+                            type: string
+                        required:
+                        - type
+                        type: object
+                    required:
+                    - storage
+                    type: object
+                  managementType:
+                    description: ManagementType defines how the etcd cluster is managed.
+                    enum:
+                    - Managed
+                    - Unmanaged
+                    type: string
+                  unmanaged:
+                    description: Unmanaged specifies configuration which enables the
+                      control plane to integrate with an eternally managed etcd cluster.
+                    properties:
+                      endpoint:
+                        description: "Endpoint is the full etcd cluster client endpoint
+                          URL. For example: \n     https://etcd-client:2379 \n If
+                          the URL uses an HTTPS scheme, the TLS field is required."
+                        pattern: ^https://
+                        type: string
+                      tls:
+                        description: TLS specifies TLS configuration for HTTPS etcd
+                          client endpoints.
+                        properties:
+                          clientSecret:
+                            description: "ClientSecret refers to a secret for client
+                              mTLS authentication with the etcd cluster. It may have
+                              the following key/value pairs: \n     etcd-client-ca.crt:
+                              Certificate Authority value     etcd-client.crt: Client
+                              certificate value     etcd-client.key: Client certificate
+                              key value"
+                            properties:
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                            type: object
+                        required:
+                        - clientSecret
+                        type: object
+                    required:
+                    - endpoint
+                    - tls
+                    type: object
+                required:
+                - managementType
+                type: object
+              fips:
+                description: FIPS indicates whether this cluster's nodes will be running
+                  in FIPS mode. If set to true, the control plane's ignition server
+                  will be configured to expect that nodes joining the cluster will
+                  be FIPS-enabled.
+                type: boolean
+              imageContentSources:
+                description: ImageContentSources specifies image mirrors that can
+                  be used by cluster nodes to pull content.
+                items:
+                  description: ImageContentSource specifies image mirrors that can
+                    be used by cluster nodes to pull content. For cluster workloads,
+                    if a container image registry host of the pullspec matches Source
+                    then one of the Mirrors are substituted as hosts in the pullspec
+                    and tried in order to fetch the image.
+                  properties:
+                    mirrors:
+                      description: Mirrors are one or more repositories that may also
+                        contain the same images.
+                      items:
+                        type: string
+                      type: array
+                    source:
+                      description: Source is the repository that users refer to, e.g.
+                        in image pull specifications.
+                      type: string
+                  required:
+                  - source
+                  type: object
+                type: array
+              infraID:
+                description: InfraID is a globally unique identifier for the cluster.
+                  This identifier will be used to associate various cloud resources
+                  with the HostedCluster and its associated NodePools.
+                type: string
+              infrastructureAvailabilityPolicy:
+                default: SingleReplica
+                description: InfrastructureAvailabilityPolicy specifies the availability
+                  policy applied to infrastructure services which run on cluster nodes.
+                  The default value is SingleReplica.
+                type: string
+              issuerURL:
+                default: https://kubernetes.default.svc
+                description: IssuerURL is an OIDC issuer URL which is used as the
+                  issuer in all ServiceAccount tokens generated by the control plane
+                  API server. The default value is kubernetes.default.svc, which only
+                  works for in-cluster validation.
+                type: string
+              networking:
+                description: Networking specifies network configuration for the cluster.
+                properties:
+                  apiServer:
+                    description: APIServer contains advanced network settings for
+                      the API server that affect how the APIServer is exposed inside
+                      a cluster node.
+                    properties:
+                      advertiseAddress:
+                        description: AdvertiseAddress is the address that nodes will
+                          use to talk to the API server. This is an address associated
+                          with the loopback adapter of each node. If not specified,
+                          172.20.0.1 is used.
+                        type: string
+                      port:
+                        description: Port is the port at which the APIServer is exposed
+                          inside a node. Other pods using host networking cannot listen
+                          on this port. If not specified, 6443 is used.
+                        format: int32
+                        type: integer
+                    type: object
+                  machineCIDR:
+                    description: "MachineCIDR is... \n TODO(dan): document it"
+                    type: string
+                  networkType:
+                    default: OVNKubernetes
+                    description: NetworkType specifies the SDN provider used for cluster
+                      networking.
+                    enum:
+                    - OpenShiftSDN
+                    - Calico
+                    - OVNKubernetes
+                    - Other
+                    type: string
+                  podCIDR:
+                    description: "PodCIDR is... \n TODO(dan): document it"
+                    type: string
+                  serviceCIDR:
+                    description: "ServiceCIDR is... \n TODO(dan): document it"
+                    type: string
+                required:
+                - machineCIDR
+                - networkType
+                - podCIDR
+                - serviceCIDR
+                type: object
+              olmCatalogPlacement:
+                default: management
+                description: OLMCatalogPlacement specifies the placement of OLM catalog
+                  components. By default, this is set to management and OLM catalog
+                  components are deployed onto the management cluster. If set to guest,
+                  the OLM catalog components will be deployed onto the guest cluster.
+                enum:
+                - management
+                - guest
+                type: string
+              pausedUntil:
+                description: 'PausedUntil is a field that can be used to pause reconciliation
+                  on a resource. Either a date can be provided in RFC3339 format or
+                  a boolean. If a date is provided: reconciliation is paused on the
+                  resource until that date. If the boolean true is provided: reconciliation
+                  is paused on the resource until the field is removed.'
+                type: string
+              platform:
+                description: Platform specifies the underlying infrastructure provider
+                  for the cluster and is used to configure platform specific behavior.
+                properties:
+                  agent:
+                    description: Agent specifies configuration for agent-based installations.
+                    properties:
+                      agentNamespace:
+                        description: AgentNamespace is the namespace where to search
+                          for Agents for this cluster
+                        type: string
+                    required:
+                    - agentNamespace
+                    type: object
+                  aws:
+                    description: AWS specifies configuration for clusters running
+                      on Amazon Web Services.
+                    properties:
+                      cloudProviderConfig:
+                        description: "CloudProviderConfig specifies AWS networking
+                          configuration for the control plane. \n TODO(dan): should
+                          this be named AWSNetworkConfig?"
+                        properties:
+                          subnet:
+                            description: Subnet is the subnet to use for control plane
+                              cloud resources.
+                            properties:
+                              arn:
+                                description: ARN of resource
+                                type: string
+                              filters:
+                                description: 'Filters is a set of key/value pairs
+                                  used to identify a resource They are applied according
+                                  to the rules defined by the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html'
+                                items:
+                                  description: Filter is a filter used to identify
+                                    an AWS resource
+                                  properties:
+                                    name:
+                                      description: Name of the filter. Filter names
+                                        are case-sensitive.
+                                      type: string
+                                    values:
+                                      description: Values includes one or more filter
+                                        values. Filter values are case-sensitive.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - name
+                                  - values
+                                  type: object
+                                type: array
+                              id:
+                                description: ID of resource
+                                type: string
+                            type: object
+                          vpc:
+                            description: VPC is the VPC to use for control plane cloud
+                              resources.
+                            type: string
+                          zone:
+                            description: Zone is the availability zone where control
+                              plane cloud resources are created.
+                            type: string
+                        required:
+                        - vpc
+                        type: object
+                      controlPlaneOperatorCreds:
+                        description: "ControlPlaneOperatorCreds is a reference to
+                          a secret containing cloud credentials with permissions matching
+                          the control-plane-operator policy. The secret should have
+                          exactly one key, `credentials`, whose value is an AWS credentials
+                          file. \n TODO(dan): document the \"control plane operator
+                          policy\""
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                      endpointAccess:
+                        default: Public
+                        description: EndpointAccess specifies the publishing scope
+                          of cluster endpoints. The default is Public.
+                        enum:
+                        - Public
+                        - PublicAndPrivate
+                        - Private
+                        type: string
+                      kubeCloudControllerCreds:
+                        description: "KubeCloudControllerCreds is a reference to a
+                          secret containing cloud credentials with permissions matching
+                          the cloud controller policy. The secret should have exactly
+                          one key, `credentials`, whose value is an AWS credentials
+                          file. \n TODO(dan): document the \"cloud controller policy\""
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                      nodePoolManagementCreds:
+                        description: "NodePoolManagementCreds is a reference to a
+                          secret containing cloud credentials with permissions matching
+                          the node pool management policy. The secret should have
+                          exactly one key, `credentials`, whose value is an AWS credentials
+                          file. \n TODO(dan): document the \"node pool management
+                          policy\""
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                      region:
+                        description: Region is the AWS region in which the cluster
+                          resides. This configures the OCP control plane cloud integrations,
+                          and is used by NodePool to resolve the correct boot AMI
+                          for a given release.
+                        type: string
+                      resourceTags:
+                        description: ResourceTags is a list of additional tags to
+                          apply to AWS resources created for the cluster. See https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html
+                          for information on tagging AWS resources. AWS supports a
+                          maximum of 50 tags per resource. OpenShift reserves 25 tags
+                          for its use, leaving 25 tags available for the user.
+                        items:
+                          description: AWSResourceTag is a tag to apply to AWS resources
+                            created for the cluster.
+                          properties:
+                            key:
+                              description: Key is the key of the tag.
+                              maxLength: 128
+                              minLength: 1
+                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
+                              type: string
+                            value:
+                              description: "Value is the value of the tag. \n Some
+                                AWS service do not support empty values. Since tags
+                                are added to resources in many services, the length
+                                of the tag value must meet the requirements of all
+                                services."
+                              maxLength: 256
+                              minLength: 1
+                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
+                              type: string
+                          required:
+                          - key
+                          - value
+                          type: object
+                        maxItems: 25
+                        type: array
+                      roles:
+                        description: "Roles must contain exactly 4 entries representing
+                          the locators for roles supporting the following OCP services:
+                          \n - openshift-ingress-operator/cloud-credentials - openshift-image-registry/installer-cloud-credentials
+                          - openshift-cluster-csi-drivers/ebs-cloud-credentials -
+                          cloud-network-config-controller/cloud-credentials \n Each
+                          role has unique permission requirements whose documentation
+                          is TBD. \n TODO(dan): revisit this field; it's really 3
+                          required fields with specific content requirements"
+                        items:
+                          properties:
+                            arn:
+                              type: string
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                          required:
+                          - arn
+                          - name
+                          - namespace
+                          type: object
+                        type: array
+                      serviceEndpoints:
+                        description: "ServiceEndpoints specifies optional custom endpoints
+                          which will override the default service endpoint of specific
+                          AWS Services. \n There must be only one ServiceEndpoint
+                          for a given service name."
+                        items:
+                          description: AWSServiceEndpoint stores the configuration
+                            for services to override existing defaults of AWS Services.
+                          properties:
+                            name:
+                              description: Name is the name of the AWS service. This
+                                must be provided and cannot be empty.
+                              type: string
+                            url:
+                              description: URL is fully qualified URI with scheme
+                                https, that overrides the default generated endpoint
+                                for a client. This must be provided and cannot be
+                                empty.
+                              pattern: ^https://
+                              type: string
+                          required:
+                          - name
+                          - url
+                          type: object
+                        type: array
+                    required:
+                    - controlPlaneOperatorCreds
+                    - kubeCloudControllerCreds
+                    - nodePoolManagementCreds
+                    - region
+                    type: object
+                  azure:
+                    description: Azure defines azure specific settings
+                    properties:
+                      credentials:
+                        description: LocalObjectReference contains enough information
+                          to let you locate the referenced object inside the same
+                          namespace.
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                      location:
+                        type: string
+                      machineIdentityID:
+                        type: string
+                      resourceGroup:
+                        type: string
+                      securityGroupName:
+                        type: string
+                      subnetName:
+                        type: string
+                      subscriptionID:
+                        type: string
+                      vnetID:
+                        type: string
+                      vnetName:
+                        type: string
+                    required:
+                    - credentials
+                    - location
+                    - machineIdentityID
+                    - resourceGroup
+                    - securityGroupName
+                    - subnetName
+                    - subscriptionID
+                    - vnetID
+                    - vnetName
+                    type: object
+                  ibmcloud:
+                    description: IBMCloud defines IBMCloud specific settings for components
+                    properties:
+                      providerType:
+                        description: ProviderType is a specific supported infrastructure
+                          provider within IBM Cloud.
+                        type: string
+                    type: object
+                  powervs:
+                    description: PowerVS specifies configuration for clusters running
+                      on IBMCloud Power VS Service. This field is immutable. Once
+                      set, It can't be changed.
+                    properties:
+                      controlPlaneOperatorCreds:
+                        description: "ControlPlaneOperatorCreds is a reference to
+                          a secret containing cloud credentials with permissions matching
+                          the control-plane-operator policy. The secret should have
+                          exactly one key, `credentials`, whose value is an AWS credentials
+                          file. This field is immutable. Once set, It can't be changed.
+                          \n TODO(dan): document the \"control plane operator policy\""
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                      kubeCloudControllerCreds:
+                        description: "KubeCloudControllerCreds is a reference to a
+                          secret containing cloud credentials with permissions matching
+                          the cloud controller policy. The secret should have exactly
+                          one key, `credentials`, whose value is an AWS credentials
+                          file. This field is immutable. Once set, It can't be changed.
+                          \n TODO(dan): document the \"cloud controller policy\""
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                      nodePoolManagementCreds:
+                        description: "NodePoolManagementCreds is a reference to a
+                          secret containing cloud credentials with permissions matching
+                          the node pool management policy. The secret should have
+                          exactly one key, `credentials`, whose value is an AWS credentials
+                          file. This field is immutable. Once set, It can't be changed.
+                          \n TODO(dan): document the \"node pool management policy\""
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                      region:
+                        description: Region is the IBMCloud region in which the cluster
+                          resides. This configures the OCP control plane cloud integrations,
+                          and is used by NodePool to resolve the correct boot image
+                          for a given release. This field is immutable. Once set,
+                          It can't be changed.
+                        type: string
+                      resourceGroup:
+                        description: ResourceGroup is the IBMCloud Resource Group
+                          in which the cluster resides. This field is immutable. Once
+                          set, It can't be changed.
+                        type: string
+                      serviceInstanceID:
+                        description: "ServiceInstance is the reference to the Power
+                          VS service on which the server instance(VM) will be created.
+                          Power VS service is a container for all Power VS instances
+                          at a specific geographic region. serviceInstance can be
+                          created via IBM Cloud catalog or CLI. ServiceInstanceID
+                          is the unique identifier that can be obtained from IBM Cloud
+                          UI or IBM Cloud cli. \n More detail about Power VS service
+                          instance. https://cloud.ibm.com/docs/power-iaas?topic=power-iaas-creating-power-virtual-server
+                          \n This field is immutable. Once set, It can't be changed."
+                        type: string
+                      subnet:
+                        description: Subnet is the subnet to use for control plane
+                          cloud resources. This field is immutable. Once set, It can't
+                          be changed.
+                        properties:
+                          id:
+                            description: ID of resource
+                            type: string
+                          name:
+                            description: Name of resource
+                            type: string
+                        type: object
+                      vpc:
+                        description: VPC specifies IBM Cloud PowerVS Load Balancing
+                          configuration for the control plane. This field is immutable.
+                          Once set, It can't be changed.
+                        properties:
+                          name:
+                            description: Name for VPC to used for all the service
+                              load balancer. This field is immutable. Once set, It
+                              can't be changed.
+                            type: string
+                          region:
+                            description: Region is the IBMCloud region in which VPC
+                              gets created, this VPC used for all the ingress traffic
+                              into the OCP cluster. This field is immutable. Once
+                              set, It can't be changed.
+                            type: string
+                          subnet:
+                            description: Subnet is the subnet to use for load balancer.
+                              This field is immutable. Once set, It can't be changed.
+                            type: string
+                          zone:
+                            description: Zone is the availability zone where load
+                              balancer cloud resources are created. This field is
+                              immutable. Once set, It can't be changed.
+                            type: string
+                        required:
+                        - name
+                        - region
+                        type: object
+                      zone:
+                        description: Zone is the availability zone where control plane
+                          cloud resources are created. This field is immutable. Once
+                          set, It can't be changed.
+                        type: string
+                    required:
+                    - controlPlaneOperatorCreds
+                    - kubeCloudControllerCreds
+                    - nodePoolManagementCreds
+                    - region
+                    - resourceGroup
+                    - serviceInstanceID
+                    - subnet
+                    - vpc
+                    - zone
+                    type: object
+                  type:
+                    description: Type is the type of infrastructure provider for the
+                      cluster.
+                    enum:
+                    - AWS
+                    - None
+                    - IBMCloud
+                    - Agent
+                    - KubeVirt
+                    - Azure
+                    - PowerVS
+                    type: string
+                required:
+                - type
+                type: object
+              pullSecret:
+                description: PullSecret references a pull secret to be injected into
+                  the container runtime of all cluster nodes. The secret must have
+                  a key named ".dockerconfigjson" whose value is the pull secret JSON.
+                properties:
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                    type: string
+                type: object
+              release:
+                description: "Release specifies the desired OCP release payload for
+                  the hosted cluster. \n Updating this field will trigger a rollout
+                  of the control plane. The behavior of the rollout will be driven
+                  by the ControllerAvailabilityPolicy and InfrastructureAvailabilityPolicy."
+                properties:
+                  image:
+                    description: Image is the image pullspec of an OCP release payload
+                      image.
+                    pattern: ^(\w+\S+)$
+                    type: string
+                required:
+                - image
+                type: object
+              secretEncryption:
+                description: SecretEncryption specifies a Kubernetes secret encryption
+                  strategy for the control plane.
+                properties:
+                  aescbc:
+                    description: AESCBC defines metadata about the AESCBC secret encryption
+                      strategy
+                    properties:
+                      activeKey:
+                        description: ActiveKey defines the active key used to encrypt
+                          new secrets
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                      backupKey:
+                        description: BackupKey defines the old key during the rotation
+                          process so previously created secrets can continue to be
+                          decrypted until they are all re-encrypted with the active
+                          key.
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                    required:
+                    - activeKey
+                    type: object
+                  kms:
+                    description: KMS defines metadata about the kms secret encryption
+                      strategy
+                    properties:
+                      aws:
+                        description: AWS defines metadata about the configuration
+                          of the AWS KMS Secret Encryption provider
+                        properties:
+                          activeKey:
+                            description: ActiveKey defines the active key used to
+                              encrypt new secrets
+                            properties:
+                              arn:
+                                description: ARN is the Amazon Resource Name for the
+                                  encryption key
+                                pattern: '^arn:'
+                                type: string
+                            required:
+                            - arn
+                            type: object
+                          auth:
+                            description: Auth defines metadata about the management
+                              of credentials used to interact with AWS KMS
+                            properties:
+                              credentials:
+                                description: Credentials contains the name of the
+                                  secret that holds the aws credentials that can be
+                                  used to make the necessary KMS calls. It should
+                                  at key AWSCredentialsFileSecretKey contain the aws
+                                  credentials file that can be used to configure AWS
+                                  SDKs
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                type: object
+                            required:
+                            - credentials
+                            type: object
+                          backupKey:
+                            description: BackupKey defines the old key during the
+                              rotation process so previously created secrets can continue
+                              to be decrypted until they are all re-encrypted with
+                              the active key.
+                            properties:
+                              arn:
+                                description: ARN is the Amazon Resource Name for the
+                                  encryption key
+                                pattern: '^arn:'
+                                type: string
+                            required:
+                            - arn
+                            type: object
+                          region:
+                            description: Region contains the AWS region
+                            type: string
+                        required:
+                        - activeKey
+                        - auth
+                        - region
+                        type: object
+                      ibmcloud:
+                        description: IBMCloud defines metadata for the IBM Cloud KMS
+                          encryption strategy
+                        properties:
+                          auth:
+                            description: Auth defines metadata for how authentication
+                              is done with IBM Cloud KMS
+                            properties:
+                              managed:
+                                description: Managed defines metadata around the service
+                                  to service authentication strategy for the IBM Cloud
+                                  KMS system (all provider managed).
+                                type: object
+                              type:
+                                description: Type defines the IBM Cloud KMS authentication
+                                  strategy
+                                enum:
+                                - Managed
+                                - Unmanaged
+                                type: string
+                              unmanaged:
+                                description: Unmanaged defines the auth metadata the
+                                  customer provides to interact with IBM Cloud KMS
+                                properties:
+                                  credentials:
+                                    description: Credentials should reference a secret
+                                      with a key field of IBMCloudIAMAPIKeySecretKey
+                                      that contains a apikey to call IBM Cloud KMS
+                                      APIs
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                    type: object
+                                required:
+                                - credentials
+                                type: object
+                            required:
+                            - type
+                            type: object
+                          keyList:
+                            description: KeyList defines the list of keys used for
+                              data encryption
+                            items:
+                              description: IBMCloudKMSKeyEntry defines metadata for
+                                an IBM Cloud KMS encryption key
+                              properties:
+                                correlationID:
+                                  description: CorrelationID is an identifier used
+                                    to track all api call usage from hypershift
+                                  type: string
+                                crkID:
+                                  description: CRKID is the customer rook key id
+                                  type: string
+                                instanceID:
+                                  description: InstanceID is the id for the key protect
+                                    instance
+                                  type: string
+                                keyVersion:
+                                  description: KeyVersion is a unique number associated
+                                    with the key. The number increments whenever a
+                                    new key is enabled for data encryption.
+                                  type: integer
+                                url:
+                                  description: URL is the url to call key protect
+                                    apis over
+                                  pattern: ^https://
+                                  type: string
+                              required:
+                              - correlationID
+                              - crkID
+                              - instanceID
+                              - keyVersion
+                              - url
+                              type: object
+                            type: array
+                          region:
+                            description: Region is the IBM Cloud region
+                            type: string
+                        required:
+                        - auth
+                        - keyList
+                        - region
+                        type: object
+                      provider:
+                        description: Provider defines the KMS provider
+                        enum:
+                        - IBMCloud
+                        - AWS
+                        type: string
+                    required:
+                    - provider
+                    type: object
+                  type:
+                    description: Type defines the type of kube secret encryption being
+                      used
+                    enum:
+                    - kms
+                    - aescbc
+                    type: string
+                required:
+                - type
+                type: object
+              serviceAccountSigningKey:
+                description: ServiceAccountSigningKey is a reference to a secret containing
+                  the private key used by the service account token issuer. The secret
+                  is expected to contain a single key named "key". If not specified,
+                  a service account signing key will be generated automatically for
+                  the cluster. When specifying a service account signing key, a IssuerURL
+                  must also be specified.
+                properties:
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                    type: string
+                type: object
+              services:
+                description: "Services specifies how individual control plane services
+                  are published from the hosting cluster of the control plane. \n
+                  If a given service is not present in this list, it will be exposed
+                  publicly by default."
+                items:
+                  description: ServicePublishingStrategyMapping specifies how individual
+                    control plane services are published from the hosting cluster
+                    of a control plane.
+                  properties:
+                    service:
+                      description: Service identifies the type of service being published.
+                      enum:
+                      - APIServer
+                      - OAuthServer
+                      - OIDC
+                      - Konnectivity
+                      - Ignition
+                      - OVNSbDb
+                      type: string
+                    servicePublishingStrategy:
+                      description: ServicePublishingStrategy specifies how to publish
+                        Service.
+                      properties:
+                        loadBalancer:
+                          description: LoadBalancer configures exposing a service
+                            using a LoadBalancer.
+                          properties:
+                            hostname:
+                              description: Hostname is the name of the DNS record
+                                that will be created pointing to the LoadBalancer.
+                              type: string
+                          type: object
+                        nodePort:
+                          description: NodePort configures exposing a service using
+                            a NodePort.
+                          properties:
+                            address:
+                              description: Address is the host/ip that the NodePort
+                                service is exposed over.
+                              type: string
+                            port:
+                              description: Port is the port of the NodePort service.
+                                If <=0, the port is dynamically assigned when the
+                                service is created.
+                              format: int32
+                              type: integer
+                          required:
+                          - address
+                          type: object
+                        route:
+                          description: Route configures exposing a service using a
+                            Route.
+                          properties:
+                            hostname:
+                              description: Hostname is the name of the DNS record
+                                that will be created pointing to the Route.
+                              type: string
+                          type: object
+                        type:
+                          description: Type is the publishing strategy used for the
+                            service.
+                          enum:
+                          - LoadBalancer
+                          - NodePort
+                          - Route
+                          - None
+                          - S3
+                          type: string
+                      required:
+                      - type
+                      type: object
+                  required:
+                  - service
+                  - servicePublishingStrategy
+                  type: object
+                type: array
+              sshKey:
+                description: SSHKey references an SSH key to be injected into all
+                  cluster node sshd servers. The secret must have a single key "id_rsa.pub"
+                  whose value is the public part of an SSH key.
+                properties:
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                    type: string
+                type: object
+            required:
+            - networking
+            - platform
+            - pullSecret
+            - release
+            - services
+            - sshKey
+            type: object
+          status:
+            description: Status is the latest observed status of the HostedCluster.
+            properties:
+              conditions:
+                description: Conditions represents the latest available observations
+                  of a control plane's current state.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    type FooStatus struct{     // Represents the observations of a
+                    foo's current state.     // Known .status.conditions.type are:
+                    \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
+                    \    // +patchStrategy=merge     // +listType=map     // +listMapKey=type
+                    \    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
+                    \n     // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              ignitionEndpoint:
+                description: IgnitionEndpoint is the endpoint injected in the ign
+                  config userdata. It exposes the config for instances to become kubernetes
+                  nodes.
+                type: string
+              kubeadminPassword:
+                description: KubeadminPassword is a reference to the secret that contains
+                  the initial kubeadmin user password for the guest cluster.
+                properties:
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                    type: string
+                type: object
+              kubeconfig:
+                description: KubeConfig is a reference to the secret containing the
+                  default kubeconfig for the cluster.
+                properties:
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                    type: string
+                type: object
+              oauthCallbackURLTemplate:
+                description: OAuthCallbackURLTemplate contains a template for the
+                  URL to use as a callback for identity providers. The [identity-provider-name]
+                  placeholder must be replaced with the name of an identity provider
+                  defined on the HostedCluster. This is populated after the infrastructure
+                  is ready.
+                type: string
+              version:
+                description: Version is the status of the release version applied
+                  to the HostedCluster.
+                properties:
+                  desired:
+                    description: desired is the version that the cluster is reconciling
+                      towards. If the cluster is not yet fully initialized desired
+                      will be set with the information available, which may be an
+                      image or a tag.
+                    properties:
+                      image:
+                        description: Image is the image pullspec of an OCP release
+                          payload image.
+                        pattern: ^(\w+\S+)$
+                        type: string
+                    required:
+                    - image
+                    type: object
+                  history:
+                    description: history contains a list of the most recent versions
+                      applied to the cluster. This value may be empty during cluster
+                      startup, and then will be updated when a new update is being
+                      applied. The newest update is first in the list and it is ordered
+                      by recency. Updates in the history have state Completed if the
+                      rollout completed - if an update was failing or halfway applied
+                      the state will be Partial. Only a limited amount of update history
+                      is preserved.
+                    items:
+                      description: UpdateHistory is a single attempted update to the
+                        cluster.
+                      properties:
+                        acceptedRisks:
+                          description: acceptedRisks records risks which were accepted
+                            to initiate the update. For example, it may menition an
+                            Upgradeable=False or missing signature that was overriden
+                            via desiredUpdate.force, or an update that was initiated
+                            despite not being in the availableUpdates set of recommended
+                            update targets.
+                          type: string
+                        completionTime:
+                          description: completionTime, if set, is when the update
+                            was fully applied. The update that is currently being
+                            applied will have a null completion time. Completion time
+                            will always be set for entries that are not the current
+                            update (usually to the started time of the next update).
+                          format: date-time
+                          nullable: true
+                          type: string
+                        image:
+                          description: image is a container image location that contains
+                            the update. This value is always populated.
+                          type: string
+                        startedTime:
+                          description: startedTime is the time at which the update
+                            was started.
+                          format: date-time
+                          type: string
+                        state:
+                          description: state reflects whether the update was fully
+                            applied. The Partial state indicates the update is not
+                            fully applied, while the Completed state indicates the
+                            update was successfully rolled out at least once (all
+                            parts of the update successfully applied).
+                          type: string
+                        verified:
+                          description: verified indicates whether the provided update
+                            was properly verified before it was installed. If this
+                            is false the cluster may not be trusted. Verified does
+                            not cover upgradeable checks that depend on the cluster
+                            state at the time when the update target was accepted.
+                          type: boolean
+                        version:
+                          description: version is a semantic versioning identifying
+                            the update version. If the requested image does not define
+                            a version, or if a failure occurs retrieving the image,
+                            this value may be empty.
+                          type: string
+                      required:
+                      - completionTime
+                      - image
+                      - startedTime
+                      - state
+                      - verified
+                      type: object
+                    type: array
+                  observedGeneration:
+                    description: observedGeneration reports which version of the spec
+                      is being synced. If this value is not equal to metadata.generation,
+                      then the desired and conditions fields may represent a previous
+                      version.
+                    format: int64
+                    type: integer
+                required:
+                - desired
+                - observedGeneration
+                type: object
+            required:
+            - conditions
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/config/crd/hypershift.openshift.io_nodepools.yaml
+++ b/config/crd/hypershift.openshift.io_nodepools.yaml
@@ -1,0 +1,749 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.5.0
+  creationTimestamp: null
+  name: nodepools.hypershift.openshift.io
+spec:
+  group: hypershift.openshift.io
+  names:
+    kind: NodePool
+    listKind: NodePoolList
+    plural: nodepools
+    shortNames:
+    - np
+    - nps
+    singular: nodepool
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Cluster
+      jsonPath: .spec.clusterName
+      name: Cluster
+      type: string
+    - description: Desired Nodes
+      jsonPath: .spec.replicas
+      name: Desired Nodes
+      type: integer
+    - description: Available Nodes
+      jsonPath: .status.replicas
+      name: Current Nodes
+      type: integer
+    - description: Autoscaling Enabled
+      jsonPath: .status.conditions[?(@.type=="AutoscalingEnabled")].status
+      name: Autoscaling
+      type: string
+    - description: Node Autorepair Enabled
+      jsonPath: .status.conditions[?(@.type=="AutorepairEnabled")].status
+      name: Autorepair
+      type: string
+    - description: Current version
+      jsonPath: .status.version
+      name: Version
+      type: string
+    - description: UpdatingVersion in progress
+      jsonPath: .status.conditions[?(@.type=="UpdatingVersion")].status
+      name: UpdatingVersion
+      type: string
+    - description: UpdatingConfig in progress
+      jsonPath: .status.conditions[?(@.type=="UpdatingConfig")].status
+      name: UpdatingConfig
+      type: string
+    - description: Message
+      jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Message
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: NodePool is a scalable set of worker nodes attached to a HostedCluster.
+          NodePool machine architectures are uniform within a given pool, and are
+          independent of the control plane’s underlying machine architecture.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec is the desired behavior of the NodePool.
+            properties:
+              autoScaling:
+                description: Autoscaling specifies auto-scaling behavior for the NodePool.
+                properties:
+                  max:
+                    description: Max is the maximum number of nodes allowed in the
+                      pool. Must be >= 1.
+                    format: int32
+                    minimum: 1
+                    type: integer
+                  min:
+                    description: Min is the minimum number of nodes to maintain in
+                      the pool. Must be >= 1.
+                    format: int32
+                    minimum: 1
+                    type: integer
+                required:
+                - max
+                - min
+                type: object
+              clusterName:
+                description: "ClusterName is the name of the HostedCluster this NodePool
+                  belongs to. \n TODO(dan): Should this be a LocalObjectReference?"
+                type: string
+              config:
+                description: "Config is a list of references to ConfigMaps containing
+                  serialized MachineConfig resources to be injected into the ignition
+                  configurations of nodes in the NodePool. The MachineConfig API schema
+                  is defined here: \n https://github.com/openshift/machine-config-operator/blob/master/pkg/apis/machineconfiguration.openshift.io/v1/types.go#L172
+                  \n Each ConfigMap must have a single key named \"config\" whose
+                  value is the JSON or YAML of a serialized MachineConfig."
+                items:
+                  description: LocalObjectReference contains enough information to
+                    let you locate the referenced object inside the same namespace.
+                  properties:
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        TODO: Add other useful fields. apiVersion, kind, uid?'
+                      type: string
+                  type: object
+                type: array
+              management:
+                description: Management specifies behavior for managing nodes in the
+                  pool, such as upgrade strategies and auto-repair behaviors.
+                properties:
+                  autoRepair:
+                    description: AutoRepair specifies whether health checks should
+                      be enabled for machines in the NodePool. The default is false.
+                    type: boolean
+                  inPlace:
+                    description: InPlace is the configuration for in-place upgrades.
+                    type: object
+                  replace:
+                    default:
+                      rollingUpdate:
+                        maxSurge: 1
+                        maxUnavailable: 0
+                      strategy: RollingUpdate
+                    description: Replace is the configuration for rolling upgrades.
+                    properties:
+                      rollingUpdate:
+                        description: RollingUpdate specifies a rolling update strategy
+                          which upgrades nodes by creating new nodes and deleting
+                          the old ones.
+                        properties:
+                          maxSurge:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: "MaxSurge is the maximum number of nodes
+                              that can be provisioned above the desired number of
+                              nodes. \n Value can be an absolute number (ex: 5) or
+                              a percentage of desired nodes (ex: 10%). \n Absolute
+                              number is calculated from percentage by rounding up.
+                              \n This can not be 0 if MaxUnavailable is 0. \n Defaults
+                              to 1. \n Example: when this is set to 30%, new nodes
+                              can be provisioned immediately when the rolling update
+                              starts, such that the total number of old and new nodes
+                              do not exceed 130% of desired nodes. Once old nodes
+                              have been deleted, new nodes can be provisioned, ensuring
+                              that total number of nodes running at any time during
+                              the update is at most 130% of desired nodes."
+                            x-kubernetes-int-or-string: true
+                          maxUnavailable:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: "MaxUnavailable is the maximum number of
+                              nodes that can be unavailable during the update. \n
+                              Value can be an absolute number (ex: 5) or a percentage
+                              of desired nodes (ex: 10%). \n Absolute number is calculated
+                              from percentage by rounding down. \n This can not be
+                              0 if MaxSurge is 0. \n Defaults to 0. \n Example: when
+                              this is set to 30%, old nodes can be deleted down to
+                              70% of desired nodes immediately when the rolling update
+                              starts. Once new nodes are ready, more old nodes be
+                              deleted, followed by provisioning new nodes, ensuring
+                              that the total number of nodes available at all times
+                              during the update is at least 70% of desired nodes."
+                            x-kubernetes-int-or-string: true
+                        type: object
+                      strategy:
+                        description: Strategy is the node replacement strategy for
+                          nodes in the pool.
+                        enum:
+                        - RollingUpdate
+                        - OnDelete
+                        type: string
+                    type: object
+                  upgradeType:
+                    description: UpgradeType specifies the type of strategy for handling
+                      upgrades.
+                    enum:
+                    - Replace
+                    - InPlace
+                    type: string
+                required:
+                - upgradeType
+                type: object
+              nodeCount:
+                description: 'Deprecated: Use Replicas instead. NodeCount will be
+                  dropped in the next api release.'
+                format: int32
+                type: integer
+              nodeDrainTimeout:
+                description: 'NodeDrainTimeout is the total amount of time that the
+                  controller will spend on draining a node. The default value is 0,
+                  meaning that the node can be drained without any time limitations.
+                  NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`
+                  TODO (alberto): Today changing this field will trigger a recreate
+                  rolling update, which kind of defeats the purpose of the change.
+                  In future we plan to propagate this field in-place. https://github.com/kubernetes-sigs/cluster-api/issues/5880'
+                type: string
+              platform:
+                description: Platform specifies the underlying infrastructure provider
+                  for the NodePool and is used to configure platform specific behavior.
+                properties:
+                  agent:
+                    description: Agent specifies the configuration used when using
+                      Agent platform.
+                    properties:
+                      agentLabelSelector:
+                        description: AgentLabelSelector contains labels that must
+                          be set on an Agent in order to be selected for a Machine.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: A label selector requirement is a selector
+                                that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship
+                                    to a set of values. Valid operators are In, NotIn,
+                                    Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: values is an array of string values.
+                                    If the operator is In or NotIn, the values array
+                                    must be non-empty. If the operator is Exists or
+                                    DoesNotExist, the values array must be empty.
+                                    This array is replaced during a strategic merge
+                                    patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: matchLabels is a map of {key,value} pairs.
+                              A single {key,value} in the matchLabels map is equivalent
+                              to an element of matchExpressions, whose key field is
+                              "key", the operator is "In", and the values array contains
+                              only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                    type: object
+                  aws:
+                    description: AWS specifies the configuration used when operating
+                      on AWS.
+                    properties:
+                      ami:
+                        description: AMI is the image id to use for node instances.
+                          If unspecified, the default is chosen based on the NodePool
+                          release payload image.
+                        type: string
+                      instanceProfile:
+                        description: InstanceProfile is the AWS EC2 instance profile,
+                          which is a container for an IAM role that the EC2 instance
+                          uses.
+                        type: string
+                      instanceType:
+                        description: InstanceType is an ec2 instance type for node
+                          instances (e.g. m5.large).
+                        type: string
+                      resourceTags:
+                        description: "ResourceTags is an optional list of additional
+                          tags to apply to AWS node instances. \n These will be merged
+                          with HostedCluster scoped tags, and HostedCluster tags take
+                          precedence in case of conflicts. \n See https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html
+                          for information on tagging AWS resources. AWS supports a
+                          maximum of 50 tags per resource. OpenShift reserves 25 tags
+                          for its use, leaving 25 tags available for the user."
+                        items:
+                          description: AWSResourceTag is a tag to apply to AWS resources
+                            created for the cluster.
+                          properties:
+                            key:
+                              description: Key is the key of the tag.
+                              maxLength: 128
+                              minLength: 1
+                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
+                              type: string
+                            value:
+                              description: "Value is the value of the tag. \n Some
+                                AWS service do not support empty values. Since tags
+                                are added to resources in many services, the length
+                                of the tag value must meet the requirements of all
+                                services."
+                              maxLength: 256
+                              minLength: 1
+                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
+                              type: string
+                          required:
+                          - key
+                          - value
+                          type: object
+                        maxItems: 25
+                        type: array
+                      rootVolume:
+                        description: RootVolume specifies configuration for the root
+                          volume of node instances.
+                        properties:
+                          iops:
+                            description: IOPS is the number of IOPS requested for
+                              the disk. This is only valid for type io1.
+                            format: int64
+                            type: integer
+                          size:
+                            description: "Size specifies size (in Gi) of the storage
+                              device. \n Must be greater than the image snapshot size
+                              or 8 (whichever is greater)."
+                            format: int64
+                            minimum: 8
+                            type: integer
+                          type:
+                            description: Type is the type of the volume.
+                            type: string
+                        required:
+                        - size
+                        - type
+                        type: object
+                      securityGroups:
+                        description: SecurityGroups is an optional set of security
+                          groups to associate with node instances.
+                        items:
+                          description: AWSResourceReference is a reference to a specific
+                            AWS resource by ID, ARN, or filters. Only one of ID, ARN
+                            or Filters may be specified. Specifying more than one
+                            will result in a validation error.
+                          properties:
+                            arn:
+                              description: ARN of resource
+                              type: string
+                            filters:
+                              description: 'Filters is a set of key/value pairs used
+                                to identify a resource They are applied according
+                                to the rules defined by the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html'
+                              items:
+                                description: Filter is a filter used to identify an
+                                  AWS resource
+                                properties:
+                                  name:
+                                    description: Name of the filter. Filter names
+                                      are case-sensitive.
+                                    type: string
+                                  values:
+                                    description: Values includes one or more filter
+                                      values. Filter values are case-sensitive.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - name
+                                - values
+                                type: object
+                              type: array
+                            id:
+                              description: ID of resource
+                              type: string
+                          type: object
+                        type: array
+                      subnet:
+                        description: Subnet is the subnet to use for node instances.
+                        properties:
+                          arn:
+                            description: ARN of resource
+                            type: string
+                          filters:
+                            description: 'Filters is a set of key/value pairs used
+                              to identify a resource They are applied according to
+                              the rules defined by the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html'
+                            items:
+                              description: Filter is a filter used to identify an
+                                AWS resource
+                              properties:
+                                name:
+                                  description: Name of the filter. Filter names are
+                                    case-sensitive.
+                                  type: string
+                                values:
+                                  description: Values includes one or more filter
+                                    values. Filter values are case-sensitive.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - name
+                              - values
+                              type: object
+                            type: array
+                          id:
+                            description: ID of resource
+                            type: string
+                        type: object
+                    required:
+                    - instanceType
+                    type: object
+                  azure:
+                    properties:
+                      availabilityZone:
+                        description: AvailabilityZone of the nodepool. Must not be
+                          specified for clusters in a location that does not support
+                          AvailabilityZone.
+                        type: string
+                      diskSizeGB:
+                        default: 120
+                        format: int32
+                        minimum: 16
+                        type: integer
+                      imageID:
+                        description: 'ImageID is the id of the image to boot from.
+                          If unset, the default image at the location below will be
+                          used: subscription/$subscriptionID/resourceGroups/$resourceGroupName/providers/Microsoft.Compute/images/rhcos.x86_64.vhd'
+                        type: string
+                      vmsize:
+                        type: string
+                    required:
+                    - vmsize
+                    type: object
+                  ibmcloud:
+                    description: IBMCloud defines IBMCloud specific settings for components
+                    properties:
+                      providerType:
+                        description: ProviderType is a specific supported infrastructure
+                          provider within IBM Cloud.
+                        type: string
+                    type: object
+                  kubevirt:
+                    description: Kubevirt specifies the configuration used when operating
+                      on KubeVirt platform.
+                    properties:
+                      compute:
+                        default:
+                          cores: 2
+                          memory: 4Gi
+                        description: Compute contains values representing the virtual
+                          hardware requested for the VM
+                        properties:
+                          cores:
+                            default: 2
+                            description: Cores represents how many cores the guest
+                              VM should have
+                            format: int32
+                            type: integer
+                          memory:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            default: 4Gi
+                            description: Memory represents how much guest memory the
+                              VM should have
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        type: object
+                      rootVolume:
+                        description: RootVolume represents values associated with
+                          the VM volume that will host rhcos
+                        properties:
+                          diskImage:
+                            description: Image represents what rhcos image to use
+                              for the node pool
+                            properties:
+                              containerDiskImage:
+                                description: ContainerDiskImage is a string representing
+                                  the container image that holds the root disk
+                                type: string
+                            type: object
+                          persistent:
+                            description: Persistent volume type means the VM's storage
+                              is backed by a PVC VMs that use persistent volumes can
+                              survive disruption events like restart and eviction
+                              This is the default type used when no storage type is
+                              defined.
+                            properties:
+                              size:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                default: 16Gi
+                                description: Size is the size of the persistent storage
+                                  volume
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              storageClass:
+                                description: StorageClass is the storageClass used
+                                  for the underlying PVC that hosts the volume
+                                type: string
+                            type: object
+                          type:
+                            default: Persistent
+                            description: Type represents the type of storage to associate
+                              with the kubevirt VMs.
+                            enum:
+                            - Persistent
+                            type: string
+                        type: object
+                    required:
+                    - rootVolume
+                    type: object
+                  powervs:
+                    description: PowerVS specifies the configuration used when using
+                      IBMCloud PowerVS platform.
+                    properties:
+                      image:
+                        description: Image used for deploying the nodes. If unspecified,
+                          the default is chosen based on the NodePool release payload
+                          image.
+                        properties:
+                          id:
+                            description: ID of resource
+                            type: string
+                          name:
+                            description: Name of resource
+                            type: string
+                        type: object
+                      imageDeletePolicy:
+                        default: delete
+                        description: "ImageDeletePolicy is policy for the image deletion.
+                          \n delete: delete the image from the infrastructure. retain:
+                          delete the image from the openshift but retain in the infrastructure.
+                          \n The default is delete"
+                        enum:
+                        - delete
+                        - retain
+                        type: string
+                      memoryGiB:
+                        default: 32
+                        description: "MemoryGiB is the size of a virtual machine's
+                          memory, in GiB. maximum value for the MemoryGiB depends
+                          on the selected SystemType. when SystemType is set to e880
+                          maximum MemoryGiB value is 7463 GiB. when SystemType is
+                          set to e980 maximum MemoryGiB value is 15307 GiB. when SystemType
+                          is set to s922 maximum MemoryGiB value is 942 GiB. The minimum
+                          memory is 32 GiB. \n When omitted, this means the user has
+                          no opinion and the platform is left to choose a reasonable
+                          default. The current default is 32."
+                        format: int32
+                        type: integer
+                      processorType:
+                        default: shared
+                        description: "ProcessorType is the VM instance processor type.
+                          It must be set to one of the following values: Dedicated,
+                          Capped or Shared. \n Dedicated: resources are allocated
+                          for a specific client, The hypervisor makes a 1:1 binding
+                          of a partition’s processor to a physical processor core.
+                          Shared: Shared among other clients. Capped: Shared, but
+                          resources do not expand beyond those that are requested,
+                          the amount of CPU time is Capped to the value specified
+                          for the entitlement. \n if the processorType is selected
+                          as Dedicated, then Processors value cannot be fractional.
+                          When omitted, this means that the user has no opinion and
+                          the platform is left to choose a reasonable default. The
+                          current default is Shared."
+                        enum:
+                        - dedicated
+                        - shared
+                        - capped
+                        type: string
+                      processors:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        default: "0.5"
+                        description: Processors is the number of virtual processors
+                          in a virtual machine. when the processorType is selected
+                          as Dedicated the processors value cannot be fractional.
+                          maximum value for the Processors depends on the selected
+                          SystemType. when SystemType is set to e880 or e980 maximum
+                          Processors value is 143. when SystemType is set to s922
+                          maximum Processors value is 15. minimum value for Processors
+                          depends on the selected ProcessorType. when ProcessorType
+                          is set as Shared or Capped, The minimum processors is 0.5.
+                          when ProcessorType is set as Dedicated, The minimum processors
+                          is 1. When omitted, this means that the user has no opinion
+                          and the platform is left to choose a reasonable default.
+                          The default is set based on the selected ProcessorType.
+                          when ProcessorType selected as Dedicated, the default is
+                          set to 1. when ProcessorType selected as Shared or Capped,
+                          the default is set to 0.5.
+                        x-kubernetes-int-or-string: true
+                      storageType:
+                        default: tier1
+                        description: "StorageType for the image and nodes, this will
+                          be ignored if Image is specified. The storage tiers in PowerVS
+                          are based on I/O operations per second (IOPS). It means
+                          that the performance of your storage volumes is limited
+                          to the maximum number of IOPS based on volume size and storage
+                          tier. Although, the exact numbers might change over time,
+                          the Tier 3 storage is currently set to 3 IOPS/GB, and the
+                          Tier 1 storage is currently set to 10 IOPS/GB. \n The default
+                          is tier1"
+                        enum:
+                        - tier1
+                        - tier3
+                        type: string
+                      systemType:
+                        default: s922
+                        description: SystemType is the System type used to host the
+                          instance. systemType determines the number of cores and
+                          memory that is available. Few of the supported SystemTypes
+                          are s922,e880,e980. e880 systemType available only in Dallas
+                          Datacenters. e980 systemType available in Datacenters except
+                          Dallas and Washington. When omitted, this means that the
+                          user has no opinion and the platform is left to choose a
+                          reasonable default. The current default is s922 which is
+                          generally available.
+                        type: string
+                    type: object
+                  type:
+                    description: Type specifies the platform name.
+                    enum:
+                    - AWS
+                    - None
+                    - IBMCloud
+                    - Agent
+                    - KubeVirt
+                    - Azure
+                    - PowerVS
+                    type: string
+                required:
+                - type
+                type: object
+              release:
+                description: Release specifies the OCP release used for the NodePool.
+                  This informs the ignition configuration for machines, as well as
+                  other platform specific machine properties (e.g. an AMI on the AWS
+                  platform).
+                properties:
+                  image:
+                    description: Image is the image pullspec of an OCP release payload
+                      image.
+                    pattern: ^(\w+\S+)$
+                    type: string
+                required:
+                - image
+                type: object
+              replicas:
+                description: Replicas is the desired number of nodes the pool should
+                  maintain. If unset, the default value is 0.
+                format: int32
+                type: integer
+            required:
+            - clusterName
+            - management
+            - platform
+            - release
+            type: object
+          status:
+            description: Status is the latest observed status of the NodePool.
+            properties:
+              conditions:
+                description: Conditions represents the latest available observations
+                  of the node pool's current state.
+                items:
+                  description: We define our own condition type since metav1.Condition
+                    has validation for Reason that might be broken by what we bubble
+                    up from CAPI. NodePoolCondition defines an observation of NodePool
+                    resource operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
+                      type: string
+                    observedGeneration:
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              replicas:
+                description: Replicas is the latest observed number of nodes in the
+                  pool.
+                format: int32
+                type: integer
+              version:
+                description: Version is the semantic version of the latest applied
+                  release specified by the NodePool.
+                type: string
+            required:
+            - conditions
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      scale:
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []


### PR DESCRIPTION
* Add get-hypershift-crds MakeFile target, HostedCluster and NodePool CRDs from openshift/hypershift, using the SHA from go.mod
* get-hypershift-crds is called when make manifests is called
* Using the go.mod SHA makes sure the CRDs match the openshift/hypershift module

Signed-off-by: Joshua Packer <jpacker@redhat.com>

<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* Since ObjectRef is now available for HostedCluster and NodePool, it makes sense to make these CRD's available.
* We now pull the appropriate version of these CRDs using the SHA in go.mod for `openshift/hypershift`

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  To use ObjectRef, you need these CRDs

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-1354

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant -->
## Test API/Unit - Success
```script
?       github.com/stolostron/hypershift-deployment-controller/api/v1alpha1     [no test files]
?       github.com/stolostron/hypershift-deployment-controller/pkg      [no test files]
?       github.com/stolostron/hypershift-deployment-controller/pkg/constant     [no test files]
ok      github.com/stolostron/hypershift-deployment-controller/pkg/controllers  2.439s  coverage: 77.0% of statements
ok      github.com/stolostron/hypershift-deployment-controller/pkg/controllers/autoimport       0.028s  coverage: 61.5% of statements
?       github.com/stolostron/hypershift-deployment-controller/pkg/helper       [no test files]
```

