### PR TITLE
Add an annotation to specify release image

### DIFF
--- a/pkg/constant/constants.go
+++ b/pkg/constant/constants.go
@@ -9,6 +9,9 @@ const (
 
 	ReleaseImage = "quay.io/openshift-release-dev/ocp-release:4.10.9-x86_64"
 
+	// AnnoReleaseImage is an annotation used to specify the release image
+	AnnoReleaseImage = "hypershiftdeployment.cluster.open-cluster-management.io/release-image"
+
 	// DestroyFinalizer makes sure infrastructure is cleaned up before it is removed
 	DestroyFinalizer = "hypershiftdeployment.cluster.open-cluster-management.io/finalizer"
 

--- a/pkg/controllers/default_resources.go
+++ b/pkg/controllers/default_resources.go
@@ -43,14 +43,16 @@ import (
 
 var resLog = ctrl.Log.WithName("resource-render")
 
-func getReleaseImagePullSpec() string {
+func getReleaseImagePullSpec(annotations map[string]string) string {
+	if releaseImage, ok := annotations[constant.AnnoReleaseImage]; ok {
+		return releaseImage
+	}
 
 	defaultVersion, err := version.LookupDefaultOCPVersion()
 	if err != nil {
 		return constant.ReleaseImage
 	}
 	return defaultVersion.PullSpec
-
 }
 
 func (r *HypershiftDeploymentReconciler) scaffoldHostedCluster(ctx context.Context, hyd *hypdeployment.HypershiftDeployment) (*unstructured.Unstructured, error) {
@@ -246,7 +248,7 @@ func scaffoldHostedClusterSpec(hyd *hypdeployment.HypershiftDeployment) {
 				// Defaults for all platforms
 				PullSecret: corev1.LocalObjectReference{Name: hyd.Name + "-pull-secret"},
 				Release: hyp.Release{
-					Image: getReleaseImagePullSpec(), //.DownloadURL,
+					Image: getReleaseImagePullSpec(hyd.Annotations), //.DownloadURL,
 				},
 				Services: []hyp.ServicePublishingStrategyMapping{
 					spsMap(hyp.APIServer, hyp.LoadBalancer),
@@ -356,7 +358,7 @@ func ScaffoldNodePoolSpec(hyd *hypdeployment.HypershiftDeployment) {
 						Type: hyp.NonePlatform,
 					},
 					Release: hyp.Release{
-						Image: getReleaseImagePullSpec(), //.DownloadURL,,
+						Image: getReleaseImagePullSpec(hyd.Annotations), //.DownloadURL,,
 					},
 				},
 			},

--- a/pkg/controllers/hypershiftdeployment_controller_test.go
+++ b/pkg/controllers/hypershiftdeployment_controller_test.go
@@ -677,3 +677,12 @@ func TestLocalObjectReferencesForHCandNP(t *testing.T) {
 	c := meta.FindStatusCondition(resultHD.Status.Conditions, string(hyd.WorkConfigured))
 	assert.Equal(t, fmt.Sprintf("HostedClusterRef %v:%v is not found", testHD.Namespace, testHD.Spec.HostedClusterRef.Name), c.Message, "is equal when hostingCluster is missing")
 }
+
+func TestGetReleaseImagePullSpec(t *testing.T) {
+	expectedReleaseImage := "quay.io/openshift-release-dev/ocp-release:4.10.16-x86_64"
+	annos := map[string]string{
+		constant.AnnoReleaseImage: expectedReleaseImage,
+	}
+	releaseImage := getReleaseImagePullSpec(annos)
+	assert.Equal(t, expectedReleaseImage, releaseImage, "is equal when annotation release image is set")
+}


### PR DESCRIPTION
Signed-off-by: zhujian <jiazhu@redhat.com>

<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* Add an annotation `hypershiftdeployment.cluster.open-cluster-management.io/release-image` for users to specify the release image.

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  This is good for testing.  the hypershift deployment controller always gets the latest openshift release image at present, but sometimes using the latest version will fail to provision nodepools, we can use this annotation to specify an ocp version.

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* 

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant -->
## Test API/Unit - Success
```script
?       github.com/stolostron/hypershift-deployment-controller/api/v1alpha1     [no test files]
?       github.com/stolostron/hypershift-deployment-controller/pkg      [no test files]
?       github.com/stolostron/hypershift-deployment-controller/pkg/constant     [no test files]
ok      github.com/stolostron/hypershift-deployment-controller/pkg/controllers  0.908s  coverage: 77.1% of statements
ok      github.com/stolostron/hypershift-deployment-controller/pkg/controllers/autoimport       0.056s  coverage: 61.5% of statements
?       github.com/stolostron/hypershift-deployment-controller/pkg/helper       [no test files]
ok      github.com/stolostron/hypershift-deployment-controller/test/integration 22.171s coverage: [no statements]
```

