### PR TITLE
Acm 1417

### DIFF
--- a/pkg/constant/constants.go
+++ b/pkg/constant/constants.go
@@ -7,7 +7,7 @@ const (
 
 	ManagedClusterCleanupFinalizer = "hypershiftdeployment.cluster.open-cluster-management.io/managedcluster-cleanup"
 
-	ReleaseImage = "quay.io/openshift-release-dev/ocp-release:4.10.9-x86_64"
+	ReleaseImage = "quay.io/openshift-release-dev/ocp-release:4.10.15-x86_64"
 
 	// DestroyFinalizer makes sure infrastructure is cleaned up before it is removed
 	DestroyFinalizer = "hypershiftdeployment.cluster.open-cluster-management.io/finalizer"

--- a/pkg/controllers/default_resources.go
+++ b/pkg/controllers/default_resources.go
@@ -48,7 +48,9 @@ func getReleaseImagePullSpec() string {
 	if err != nil {
 		return constant.ReleaseImage
 	}
-	return defaultVersion.PullSpec
+	//return defaultVersion.PullSpec
+	// Bug patch: acm-1417 acm-1420
+	return constant.ReleaseImage
 
 }
 

--- a/pkg/controllers/default_resources.go
+++ b/pkg/controllers/default_resources.go
@@ -164,6 +164,7 @@ func ScaffoldAzureHostedClusterSpec(hyd *hypdeployment.HypershiftDeployment, inf
 	hyd.Spec.HostedClusterSpec.DNS = *scaffoldDnsSpec(infraOut.BaseDomain, infraOut.PrivateZoneID, infraOut.PublicZoneID)
 	hyd.Spec.HostedClusterSpec.Platform.Azure = ap
 	hyd.Spec.HostedClusterSpec.Platform.Type = hyp.AzurePlatform
+	hyd.Spec.HostedClusterSpec.InfraID = hyd.Spec.InfraID
 }
 
 func ScaffoldAWSHostedClusterSpec(hyd *hypdeployment.HypershiftDeployment, infraOut *aws.CreateInfraOutput) {

--- a/pkg/controllers/default_resources.go
+++ b/pkg/controllers/default_resources.go
@@ -25,7 +25,6 @@ import (
 	hyp "github.com/openshift/hypershift/api/v1alpha1"
 	"github.com/openshift/hypershift/cmd/infra/aws"
 	"github.com/openshift/hypershift/cmd/infra/azure"
-	"github.com/openshift/hypershift/cmd/version"
 	hypdeployment "github.com/stolostron/hypershift-deployment-controller/api/v1alpha1"
 	"github.com/stolostron/hypershift-deployment-controller/pkg/constant"
 	"github.com/stolostron/hypershift-deployment-controller/pkg/helper"
@@ -44,12 +43,13 @@ var resLog = ctrl.Log.WithName("resource-render")
 
 func getReleaseImagePullSpec() string {
 
+	/* Bug patch: acm-1417 acm-1420
 	defaultVersion, err := version.LookupDefaultOCPVersion()
 	if err != nil {
 		return constant.ReleaseImage
 	}
-	//return defaultVersion.PullSpec
-	// Bug patch: acm-1417 acm-1420
+	return defaultVersion.PullSpec
+	*/
 	return constant.ReleaseImage
 
 }

--- a/samples/aws.custom.cluster.yaml
+++ b/samples/aws.custom.cluster.yaml
@@ -51,10 +51,10 @@ spec:
             maxUnavailable: 0
           strategy: RollingUpdate
         upgradeType: Replace
-     platform:
-        aws:
-          instanceType: t3.large
-        type: AWS
+       platform:
+         aws:
+           instanceType: t3.large
+         type: AWS
       release:
         image: quay.io/openshift-release-dev/ocp-release:4.10.15-x86_64 # Default
       replicas: 2

--- a/samples/aws.custom.cluster.yaml
+++ b/samples/aws.custom.cluster.yaml
@@ -51,6 +51,10 @@ spec:
             maxUnavailable: 0
           strategy: RollingUpdate
         upgradeType: Replace
+     platform:
+        aws:
+          instanceType: t3.large
+        type: AWS
       release:
         image: quay.io/openshift-release-dev/ocp-release:4.10.15-x86_64 # Default
       replicas: 2

--- a/samples/aws.custom.cluster.yaml
+++ b/samples/aws.custom.cluster.yaml
@@ -1,0 +1,63 @@
+# This is an example Hypershift deployment for AWS using us-east-1 region and fully configuring two t3.large worker nodes.
+# The following values need to be set:
+# <cluster> - The name to provision the cluster with
+# <my-secret> - The name of the Provider Credential secret created by ACM/MCE
+# Other fields can be customized as well, but the "configure: true" setting may overwrite them
+#
+
+apiVersion: cluster.open-cluster-management.io/v1alpha1
+kind: HypershiftDeployment
+metadata:
+  name: <cluster>
+  namespace: default
+spec:
+  hostingCluster: local-cluster
+  hostingNamespace: clusters
+  hostedClusterSpec:
+    networking:
+      machineCIDR: 10.0.0.0/16    # Default
+      networkType: OpenShiftSDN
+      podCIDR: 10.132.0.0/14      # Default
+      serviceCIDR: 172.31.0.0/16  # Default
+    platform:
+      type: AWS
+    pullSecret:
+      name: <cluster>-pull-secret    # This secret is created by the controller
+    release:
+      image: quay.io/openshift-release-dev/ocp-release:4.10.15-x86_64  # Default
+    services:
+    - service: APIServer
+      servicePublishingStrategy:
+        type: LoadBalancer
+    - service: OAuthServer
+      servicePublishingStrategy:
+        type: Route
+    - service: Konnectivity
+      servicePublishingStrategy:
+        type: Route
+    - service: Ignition
+      servicePublishingStrategy:
+        type: Route
+    sshKey: {}
+  nodePools:
+  - name: <cluster>
+    spec:
+      clusterName: <cluster>
+      management:
+        autoRepair: false
+        replace:
+          rollingUpdate:
+            maxSurge: 1
+            maxUnavailable: 0
+          strategy: RollingUpdate
+        upgradeType: Replace
+      release:
+        image: quay.io/openshift-release-dev/ocp-release:4.10.15-x86_64 # Default
+      replicas: 2
+  infrastructure:
+    cloudProvider:
+      name: <my-secret>
+    configure: True
+    platform:
+      aws:
+        region: <region>


### PR DESCRIPTION
Signed-off-by: Joshua Packer <jpacker@redhat.com>

<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* hard code the version to 4.10.15 as the default OCP to deploy

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  Otherwise the default is 4.11 which does not deploy.
   * In which case you need to deploy with `override: INFRA-ONLY`, then update the release before removing `override: INRA-ONLY`

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* acm-1417, full fix should be in acm-1420

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant -->
## Test API/Unit - Success
```script
?       github.com/stolostron/hypershift-deployment-controller/api/v1alpha1     [no test files]
?       github.com/stolostron/hypershift-deployment-controller/pkg      [no test files]
?       github.com/stolostron/hypershift-deployment-controller/pkg/constant     [no test files]
ok      github.com/stolostron/hypershift-deployment-controller/pkg/controllers  0.131s  coverage: 77.9% of statements
ok      github.com/stolostron/hypershift-deployment-controller/pkg/controllers/autoimport       0.023s  coverage: 61.5% of statements
?       github.com/stolostron/hypershift-deployment-controller/pkg/helper       [no test files]
ok      github.com/stolostron/hypershift-deployment-controller/test/integration 20.991s coverage: [no statements]
```

