### PR TITLE
Remove hostedcluster and nodepool while deleting hyd

### DIFF
--- a/pkg/controllers/hypershiftdeployment_controller.go
+++ b/pkg/controllers/hypershiftdeployment_controller.go
@@ -329,7 +329,7 @@ func (r *HypershiftDeploymentReconciler) destroyHypershift(hyd *hypdeployment.Hy
 	}
 
 	if hyd.Spec.Override != hypdeployment.InfraConfigureOnly {
-		log.Info("Removing Manifestwork and wait for hostedclsuter and nodepool to be cleaned up.")
+		log.Info("Removing Manifestwork and wait for hostedcluster and nodepool to be cleaned up.")
 		res, err := r.deleteManifestworkWaitCleanUp(ctx, hyd)
 
 		if stErr := r.Client.Status().Patch(ctx, hyd, client.MergeFrom(inHyd)); stErr != nil {

--- a/test/integration/manifest_test.go
+++ b/test/integration/manifest_test.go
@@ -21,6 +21,68 @@ import (
 	"github.com/stolostron/hypershift-deployment-controller/pkg/constant"
 )
 
+func injectStatusFeedBackValues(c client.Client, hyd hypdeployment.HypershiftDeployment) bool {
+	mw := &workv1.ManifestWork{}
+	err := c.Get(ctx, client.ObjectKey{Namespace: hyd.Spec.HostingCluster,
+		Name: hyd.Spec.InfraID}, mw)
+	if apierrors.IsNotFound(err) {
+		return true
+	}
+	if err != nil {
+		return false
+	}
+
+	hasOwnerReferenceConfig := false
+	for _, c := range mw.Spec.ManifestConfigs {
+		if c.ResourceIdentifier.Resource == "hostedclusters" {
+			for _, r := range c.FeedbackRules {
+				if r.Type == workv1.JSONPathsType {
+					for _, p := range r.JsonPaths {
+						if p.Name == "owner" {
+							hasOwnerReferenceConfig = true
+						}
+					}
+				}
+			}
+		}
+	}
+
+	if hasOwnerReferenceConfig {
+		dpmw := mw.DeepCopy()
+		fakeManifestOwner := "fake-owner"
+		if len(mw.Status.ResourceStatus.Manifests) == 0 {
+			mw.Status.ResourceStatus.Manifests = []workv1.ManifestCondition{
+				{
+					ResourceMeta: workv1.ManifestResourceMeta{
+						Group:     hyp.GroupVersion.Group,
+						Resource:  "hostedclusters",
+						Name:      hyd.Name,
+						Namespace: hyd.Spec.HostingNamespace,
+					},
+					StatusFeedbacks: workv1.StatusFeedbackResult{
+						Values: []workv1.FeedbackValue{
+							{
+								Name: "owner",
+								Value: workv1.FieldValue{
+									Type:   workv1.String,
+									String: &fakeManifestOwner,
+								},
+							},
+						},
+					},
+				},
+			}
+		}
+		patch := client.MergeFrom(dpmw)
+		if err := c.Status().Patch(ctx, mw, patch); err != nil {
+			return false
+		}
+		return true
+	}
+
+	return false
+}
+
 var _ = ginkgo.Describe("Manifest Work", func() {
 	var (
 		hydName        string
@@ -136,6 +198,10 @@ var _ = ginkgo.Describe("Manifest Work", func() {
 			gomega.Eventually(func() bool {
 				hydDeleting := hypdeployment.HypershiftDeployment{}
 				err := mgr.GetClient().Get(ctx, client.ObjectKey{Namespace: hydNamespace, Name: hydName}, &hydDeleting)
+				if err == nil {
+					_ = injectStatusFeedBackValues(mgr.GetClient(), hydDeleting)
+				}
+
 				return apierrors.IsNotFound(err)
 			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeTrue())
 
@@ -387,6 +453,9 @@ var _ = ginkgo.Describe("Manifest Work", func() {
 			gomega.Eventually(func() bool {
 				hydDeleting := hypdeployment.HypershiftDeployment{}
 				err := mgr.GetClient().Get(ctx, client.ObjectKey{Namespace: hydNamespace, Name: hydName}, &hydDeleting)
+				if err == nil {
+					_ = injectStatusFeedBackValues(mgr.GetClient(), hydDeleting)
+				}
 				return apierrors.IsNotFound(err)
 			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeTrue())
 


### PR DESCRIPTION
make sure the work agent consumed the delete option changes before deleting the manifestwork

Signed-off-by: zhujian <jiazhu@redhat.com>

<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* ~~Add an machine config for the manifestwork to get the ownerreference of the hosted cluster before deleting the manifestwork~~
* ~~Check whether the ownerreference exists, if it exists that means the work agent can make sure the hosted cluster will be deleted before the manifestwork deletion(Foreground)~~
* Use `manifestwork.status.conditions[?(@.type=="Available")].observedGeneration==manifestwork.generation` to make sure the delete option change is consumed by the work agent before deleting the manifestwork

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  To fix issue https://issues.redhat.com/browse/ACM-1403

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-1403

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant -->
## Test API/Unit - Success
```script
?   	github.com/stolostron/hypershift-deployment-controller/api/v1alpha1	[no test files]
?   	github.com/stolostron/hypershift-deployment-controller/pkg	[no test files]
?   	github.com/stolostron/hypershift-deployment-controller/pkg/constant	[no test files]
ok  	github.com/stolostron/hypershift-deployment-controller/pkg/controllers	1.166s	coverage: 76.8% of statements
ok  	github.com/stolostron/hypershift-deployment-controller/pkg/controllers/autoimport	0.036s	coverage: 61.5% of statements
?   	github.com/stolostron/hypershift-deployment-controller/pkg/helper	[no test files]
ok  	github.com/stolostron/hypershift-deployment-controller/test/integration	28.381s	coverage: [no statements]
```

