### PR TITLE
Update owners files. Quick fix to manifestwork security constraints check

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -5,6 +5,7 @@ approvers:
 - zhujian7
 - rokej
 - philipwu08
+- mikeshng
 reviewers:
 - jnpacker
 - elgnay
@@ -12,3 +13,4 @@ reviewers:
 - zhujian7
 - rokej
 - philipwu08
+- mikeshng

--- a/pkg/controllers/manifestwork.go
+++ b/pkg/controllers/manifestwork.go
@@ -245,12 +245,12 @@ func (r *HypershiftDeploymentReconciler) createOrUpdateMainfestwork(ctx context.
 
 	passedSecurity, statusUpdateErr := r.validateSecurityConstraints(ctx, hyd)
 	if !passedSecurity {
-		return ctrl.Result{}, statusUpdateErr
+		return ctrl.Result{RequeueAfter: time.Minute * 1}, statusUpdateErr
 	}
 
 	m, err := scaffoldManifestwork(hyd)
 	if err != nil {
-		return ctrl.Result{RequeueAfter: time.Minute * 1}, err
+		return ctrl.Result{}, err
 	}
 
 	mwCfg := enableManifestStatusFeedback(m, hyd)

--- a/pkg/main.go
+++ b/pkg/main.go
@@ -34,6 +34,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	mcv1 "open-cluster-management.io/api/cluster/v1"
+	mcv1beta1 "open-cluster-management.io/api/cluster/v1beta1"
 	workv1 "open-cluster-management.io/api/work/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
@@ -58,6 +59,8 @@ func init() {
 	utilruntime.Must(workv1.AddToScheme(scheme))
 
 	utilruntime.Must(mcv1.AddToScheme(scheme))
+
+	utilruntime.Must(mcv1beta1.AddToScheme(scheme))
 
 	//+kubebuilder:scaffold:scheme
 }


### PR DESCRIPTION
Signed-off-by: Mike Ng <ming@redhat.com>

<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* Update owner file with my GitHub ID
* Fix manifestwork security validation not reconcile after a fail check.

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  Fix manifestwork security validation not reconcile after a fail check.

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-1261

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant -->
## Test API/Unit - Success
```script
?   	github.com/stolostron/hypershift-deployment-controller/api/v1alpha1	[no test files]
?   	github.com/stolostron/hypershift-deployment-controller/pkg	[no test files]
ok  	github.com/stolostron/hypershift-deployment-controller/pkg/client	0.088s	coverage: 87.5% of statements
?   	github.com/stolostron/hypershift-deployment-controller/pkg/constant	[no test files]
ok  	github.com/stolostron/hypershift-deployment-controller/pkg/controllers	2.852s	coverage: 77.2% of statements
ok  	github.com/stolostron/hypershift-deployment-controller/pkg/controllers/autoimport	0.110s	coverage: 60.6% of statements
ok  	github.com/stolostron/hypershift-deployment-controller/pkg/helper	0.156s	coverage: 62.5% of statements
ok  	github.com/stolostron/hypershift-deployment-controller/test/integration	22.971s	coverage: [no statements]

```

