### PR TITLE
Default the OCP image to 4.10.15

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ vet: ## Run go vet against code.
 
 .PHONY: test
 test: manifests generate fmt vet envtest ## Run tests.
-	XDG_CACHE_HOME="/tmp" KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -coverprofile cover.out
+	XDG_CACHE_HOME="/tmp" KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -coverprofile cover.out --timeout 60s
 
 ##@ Build
 .PHONY: vendor

--- a/pkg/constant/constants.go
+++ b/pkg/constant/constants.go
@@ -7,7 +7,7 @@ const (
 
 	ManagedClusterCleanupFinalizer = "hypershiftdeployment.cluster.open-cluster-management.io/managedcluster-cleanup"
 
-	ReleaseImage = "quay.io/openshift-release-dev/ocp-release:4.10.9-x86_64"
+	ReleaseImage = "quay.io/openshift-release-dev/ocp-release:4.10.15-x86_64"
 
 	// DestroyFinalizer makes sure infrastructure is cleaned up before it is removed
 	DestroyFinalizer = "hypershiftdeployment.cluster.open-cluster-management.io/finalizer"

--- a/pkg/controllers/hypershiftdeployment_controller_test.go
+++ b/pkg/controllers/hypershiftdeployment_controller_test.go
@@ -138,6 +138,42 @@ func scaffoldTestNodePool(hyd *hypdeployment.HypershiftDeployment, npName string
 	}
 }
 
+func TestScaffoldHostedClusterSpec(t *testing.T) {
+
+	t.Log("Testing AWS scaffolding")
+	testHD := getHypershiftDeployment("default", "test1", false)
+	testHD.Spec.HostedClusterSpec = &hyp.HostedClusterSpec{
+		//IssuerURL: iamOut.IssuerURL,
+		Networking: hyp.ClusterNetworking{
+			ServiceCIDR: "",
+			PodCIDR:     "",
+			MachineCIDR: "", //This is overwritten below
+			NetworkType: hyp.OpenShiftSDN,
+		},
+		// Defaults for all platforms
+		PullSecret: corev1.LocalObjectReference{Name: ""},
+		Release: hyp.Release{
+			Image: getReleaseImagePullSpec(), //.DownloadURL,
+		},
+		Services: []hyp.ServicePublishingStrategyMapping{},
+	}
+
+	scaffoldHostedClusterSpec(testHD)
+	assert.Equal(t, testHD.Spec.HostedClusterSpec.PullSecret.Name,
+		"test1-pull-secret", "Equal when pull secret name is populated")
+	assert.Equal(t, testHD.Spec.HostedClusterSpec.Release.Image,
+		"quay.io/openshift-release-dev/ocp-release:4.10.15-x86_64",
+		"The image we update at release time as stable")
+	assert.Equal(t, testHD.Spec.HostedClusterSpec.Networking.ServiceCIDR,
+		"172.31.0.0/16", "default serviceCIDR")
+	assert.Equal(t, testHD.Spec.HostedClusterSpec.Networking.PodCIDR,
+		"10.132.0.0/14", "default podCIDR")
+	assert.Equal(t, testHD.Spec.HostedClusterSpec.Networking.MachineCIDR, "",
+		"if code above ran, this will be empty")
+	assert.NotEqual(t, testHD.Spec.HostedClusterSpec.Services, []hyp.ServicePublishingStrategyMapping{},
+		"services should not be an empty list")
+}
+
 func TestScaffoldAWSHostedClusterSpec(t *testing.T) {
 
 	t.Log("Test AWS scaffolding")


### PR DESCRIPTION
* Fix a problem when auto-configuring Azure, that we miss the infraId.
* Automatically fill the Network podCIDR and serviceCIDR.
* Fill the pull secret name if missing

Signed-off-by: Joshua Packer <jpacker@redhat.com>

<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* Fix a problem where 4.11 is being presented as the default OCP release

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  You can't do the simple deploy flow, it's broken. Real fix will be in acm-1420

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* acm-1417

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant -->
## Test API/Unit - Success
```script
?       github.com/stolostron/hypershift-deployment-controller/api/v1alpha1     [no test files]
?       github.com/stolostron/hypershift-deployment-controller/pkg      [no test files]
ok      github.com/stolostron/hypershift-deployment-controller/pkg/client       0.052s  coverage: 87.5% of statements
?       github.com/stolostron/hypershift-deployment-controller/pkg/constant     [no test files]
ok      github.com/stolostron/hypershift-deployment-controller/pkg/controllers  0.214s  coverage: 77.6% of statements
ok      github.com/stolostron/hypershift-deployment-controller/pkg/controllers/autoimport       0.042s  coverage: 60.6% of statements
ok      github.com/stolostron/hypershift-deployment-controller/pkg/helper       0.041s  coverage: 62.5% of statements
ok      github.com/stolostron/hypershift-deployment-controller/test/integration 21.230s coverage: [no statements]
```

