### PR TITLE
Missed configuring the release image in the nodePool if its missing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ vet: ## Run go vet against code.
 
 .PHONY: test
 test: manifests generate fmt vet envtest ## Run tests.
-	XDG_CACHE_HOME="/tmp" KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -coverprofile cover.out --timeout 60s
+	XDG_CACHE_HOME="/tmp" KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -coverprofile cover.out
 
 ##@ Build
 .PHONY: vendor

--- a/pkg/controllers/default_resources.go
+++ b/pkg/controllers/default_resources.go
@@ -299,9 +299,12 @@ func ScaffoldAzureNodePoolSpec(hyd *hypdeployment.HypershiftDeployment, infraOut
 		if np.Spec.Platform.Azure == nil {
 			np.Spec.Platform.Azure = &hyp.AzureNodePoolPlatform{
 				VMSize:     "Standard_D4s_v4",
-				ImageID:    infraOut.BootImageID,
 				DiskSizeGB: int32(120),
 			}
+		}
+		// this code only runs when configure: true, inserts above, even if missing
+		if np.Spec.Platform.Azure.ImageID == "" {
+			np.Spec.Platform.Azure.ImageID = infraOut.BootImageID
 		}
 	}
 }


### PR DESCRIPTION
Signed-off-by: Joshua Packer <jpacker@redhat.com>

<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* We should insert the release image if its not provided in a custom configuration with configure: true
* Remove go test -timeout, this was erroneously added.

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  So that we don't fail to deploy

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* acm-1417

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant -->
## Test API/Unit - Success
```script
?       github.com/stolostron/hypershift-deployment-controller/api/v1alpha1     [no test files]
?       github.com/stolostron/hypershift-deployment-controller/pkg      [no test files]
ok      github.com/stolostron/hypershift-deployment-controller/pkg/client       0.101s  coverage: 87.5% of statements
?       github.com/stolostron/hypershift-deployment-controller/pkg/constant     [no test files]
ok      github.com/stolostron/hypershift-deployment-controller/pkg/controllers  0.238s  coverage: 77.7% of statements
ok      github.com/stolostron/hypershift-deployment-controller/pkg/controllers/autoimport       0.077s  coverage: 60.6% of statements
ok      github.com/stolostron/hypershift-deployment-controller/pkg/helper       0.071s  coverage: 62.5% of statements
ok      github.com/stolostron/hypershift-deployment-controller/test/integration 21.296s coverage: [no statements]
```

