### PR TITLE
Add Spec.HostedClusterSetLabels to allow setting of the cluster set labels

### DIFF
--- a/api/v1alpha1/hypershiftdeployment_types.go
+++ b/api/v1alpha1/hypershiftdeployment_types.go
@@ -115,6 +115,10 @@ type HypershiftDeploymentSpec struct {
 	// +optional
 	HostedClusterSpec *hypv1alpha1.HostedClusterSpec `json:"hostedClusterSpec,omitempty"`
 
+	// HostedClusterSetLabels specify the ManagedClusterSet labels for the newly imported  hosted cluster to the hub cluster.
+	// +optional
+	HostedClusterSetLabels map[string]string `json:"hostedClusterSetLabels,omitempty"`
+
 	// Reference to a HostedCluster on the HyperShift deployment namespace that will be applied to the
 	// ManagementCluster by ACM, if omitted, it will be generated
 	// required if InfraSpec.Configure is false

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -161,6 +161,13 @@ func (in *HypershiftDeploymentSpec) DeepCopyInto(out *HypershiftDeploymentSpec) 
 		*out = new(apiv1alpha1.HostedClusterSpec)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.HostedClusterSetLabels != nil {
+		in, out := &in.HostedClusterSetLabels, &out.HostedClusterSetLabels
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	out.HostedClusterRef = in.HostedClusterRef
 	if in.NodePools != nil {
 		in, out := &in.NodePools, &out.NodePools

--- a/config/crd/cluster.open-cluster-management.io_hypershiftdeployments.yaml
+++ b/config/crd/cluster.open-cluster-management.io_hypershiftdeployments.yaml
@@ -98,6 +98,12 @@ spec:
                       TODO: Add other useful fields. apiVersion, kind, uid?'
                     type: string
                 type: object
+              hostedClusterSetLabels:
+                additionalProperties:
+                  type: string
+                description: HostedClusterSetLabels specify the ManagedClusterSet
+                  labels for the newly imported  hosted cluster to the hub cluster.
+                type: object
               hostedClusterSpec:
                 description: HostedCluster that will be applied to the ManagementCluster
                   by ACM, if omitted, it will be generated


### PR DESCRIPTION
Add Spec.HostedClusterSetLabels to allow setting of the cluster set labels during auto import of newly created hosted cluster to hub.

Signed-off-by: Mike Ng <ming@redhat.com>

<!-- Include a list of changes, include what this PR does -->
* Add optional Spec.HostedClusterSetLabels to the HypershiftDeployment CRD
* If the field is populated then those labels will be set during auto import of newly created hosted cluster to hub.

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  Allow the newly created managed cluster to belong to multiple clusterSets

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-1261

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant -->
## Test API/Unit - Success
```script
?   	github.com/stolostron/hypershift-deployment-controller/api/v1alpha1	[no test files]
?   	github.com/stolostron/hypershift-deployment-controller/pkg	[no test files]
ok  	github.com/stolostron/hypershift-deployment-controller/pkg/client	0.024s	coverage: 87.5% of statements
?   	github.com/stolostron/hypershift-deployment-controller/pkg/constant	[no test files]
ok  	github.com/stolostron/hypershift-deployment-controller/pkg/controllers	0.182s	coverage: 77.9% of statements
ok  	github.com/stolostron/hypershift-deployment-controller/pkg/controllers/autoimport	0.032s	coverage: 61.7% of statements
ok  	github.com/stolostron/hypershift-deployment-controller/pkg/helper	0.032s	coverage: 62.5% of statements
ok  	github.com/stolostron/hypershift-deployment-controller/test/integration	21.312s	coverage: [no statements]
```