### PR TITLE
Add additional testing for deleteManifestworkWaitCleanUp to bring cov…

### DIFF
--- a/pkg/controllers/manifestwork_test.go
+++ b/pkg/controllers/manifestwork_test.go
@@ -1666,8 +1666,9 @@ func TestDeleteManifestworkWaitCleanUp(t *testing.T) {
 	rqst, err := hdr.deleteManifestworkWaitCleanUp(ctx, testHD)
 	assert.Nil(t, err, "is nil when deleteManifestWorkWaitCleanUp is successful")
 	assert.EqualValues(t, ctrl.Result{RequeueAfter: 1 * time.Second, Requeue: true}, rqst, "request requeue should be 1s")
-
 	err = client.Get(ctx, types.NamespacedName{Name: mw.Name, Namespace: mw.Namespace}, mw)
+	assert.Equal(t, workv1.DeletePropagationPolicyTypeSelectivelyOrphan, mw.Spec.DeleteOption.PropagationPolicy,
+		"set selectivelyOrphan and not orphan")
 	mw.Status.Conditions = []metav1.Condition{
 		metav1.Condition{
 			Type:               string(workv1.WorkAvailable),
@@ -1675,7 +1676,7 @@ func TestDeleteManifestworkWaitCleanUp(t *testing.T) {
 			Status:             metav1.ConditionTrue,
 		},
 	}
-	err = client.Update(ctx, mw)
+	err = client.Status().Update(ctx, mw)
 	assert.Nil(t, err, "is nil when condition is added")
 
 	rqst, err = hdr.deleteManifestworkWaitCleanUp(ctx, testHD)


### PR DESCRIPTION
…erage over 80%

Signed-off-by: Joshua Packer <jpacker@redhat.com>

<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* Improve test coverage

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  We dropped test coverage by a bit

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* [acm-1403 ](https://issues.redhat.com/browse/ACM-1403)

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant -->
## Test API/Unit - Success
```script
?       github.com/stolostron/hypershift-deployment-controller/api/v1alpha1     [no test files]
?       github.com/stolostron/hypershift-deployment-controller/pkg      [no test files]
ok      github.com/stolostron/hypershift-deployment-controller/pkg/client       0.036s  coverage: 87.5% of statements
?       github.com/stolostron/hypershift-deployment-controller/pkg/constant     [no test files]
ok      github.com/stolostron/hypershift-deployment-controller/pkg/controllers  0.149s  coverage: 80.1% of statements
ok      github.com/stolostron/hypershift-deployment-controller/pkg/controllers/autoimport       0.028s  coverage: 60.6% of statements
ok      github.com/stolostron/hypershift-deployment-controller/pkg/helper       0.024s  coverage: 62.5% of statements
ok      github.com/stolostron/hypershift-deployment-controller/test/integration 27.650s coverage: [no statements]
```

