### PR TITLE
Update local-cluster info in MCE doc

### DIFF
--- a/.github/workflows/crd-compare.yml
+++ b/.github/workflows/crd-compare.yml
@@ -33,13 +33,13 @@ jobs:
         with:
           payload: |
             {
-              "text": ":warning::warning: Announcement: `HypershiftDeployment` CRD compare result: ${{ job.status }} :warning::warning:\n${{ github.event.pull_request.html_url || github.event.type }}",
+              "text": ":alert-siren: Announcement: `HypershiftDeployment` CRD compare result: ${{ job.status }} \n${{ github.event.pull_request.html_url || github.event.type }}",
               "blocks": [
                 {
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": ":warning::warning: Announcement: `HypershiftDeployment` CRD compare result: ${{ job.status }} :warning::warning:\n${{ github.event.pull_request.html_url || github.event.type }}"
+                    "text": ":alert-siren: Announcement: `HypershiftDeployment` CRD compare result: ${{ job.status }} \n${{ github.event.pull_request.html_url || github.event.type }}"
                   }
                 }
               ]

--- a/config/crd/hypershift.openshift.io_nodepools.yaml
+++ b/config/crd/hypershift.openshift.io_nodepools.yaml
@@ -105,7 +105,7 @@ spec:
                 description: "Config is a list of references to ConfigMaps containing
                   serialized MachineConfig resources to be injected into the ignition
                   configurations of nodes in the NodePool. The MachineConfig API schema
-                  is defined here: \n https://github.com/openshift/machine-config-operator/blob/master/pkg/apis/machineconfiguration.openshift.io/v1/types.go#L172
+                  is defined here: \n https://github.com/openshift/machine-config-operator/blob/18963e4f8fe66e8c513ca4b131620760a414997f/pkg/apis/machineconfiguration.openshift.io/v1/types.go#L185
                   \n Each ConfigMap must have a single key named \"config\" whose
                   value is the JSON or YAML of a serialized MachineConfig."
                 items:

--- a/docs/provision_hypershift_clusters_by_mce.md
+++ b/docs/provision_hypershift_clusters_by_mce.md
@@ -1,6 +1,20 @@
 # Provision Hypershift Clusters by MCE
 
-The multicluster-engine(MCE) has been installed and at least one OCP managed cluster(e.g. `hypershift-management-cluster`, If you want the hub cluster to act as a hypershift management cluster, you can also use `local-cluster`) has been imported. We will make this OCP managed cluster a hypershift management cluster.
+The multicluster-engine(MCE) has been installed and at least one OCP managed cluster. We will make this OCP managed cluster a hypershift management cluster. It is possible to use the hub cluster to act as a hypershift management cluster, however, this requires importing the hub cluster as an OCP managed cluster called `local-cluster`:
+
+```bash
+$ oc apply -f - <<EOF
+apiVersion: cluster.open-cluster-management.io/v1
+kind: ManagedCluster
+metadata:
+  labels:
+    local-cluster: "true"
+  name: local-cluster
+spec:
+  hubAcceptsClient: true
+  leaseDurationSeconds: 60
+EOF
+```
 
 ## Enable the hypershift related components on the hub cluster
 

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/onsi/ginkgo/v2 v2.1.3
 	github.com/onsi/gomega v1.18.1
-	github.com/openshift/hypershift v0.0.0-20220530194701-151246fd8480
+	github.com/openshift/hypershift v0.0.0-20220607131543-f684373220da
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.7.0
 	go.uber.org/zap v1.19.1

--- a/go.sum
+++ b/go.sum
@@ -905,8 +905,8 @@ github.com/openshift/cluster-api-provider-kubevirt v0.0.0-20211223062810-ef64d5f
 github.com/openshift/cluster-api-provider-kubevirt v0.0.0-20211223062810-ef64d5ff1cde/go.mod h1:Z4fR4Cg8/z9GEys79MU+8CpX98aZQqI+tl9YIao0KxQ=
 github.com/openshift/custom-resource-status v0.0.0-20200602122900-c002fd1547ca h1:F1MEnOMwSrTA0YAkO0he9ip9w0JhYzI/iCB2mXmaSPg=
 github.com/openshift/custom-resource-status v0.0.0-20200602122900-c002fd1547ca/go.mod h1:GDjWl0tX6FNIj82vIxeudWeSx2Ff6nDZ8uJn0ohUFvo=
-github.com/openshift/hypershift v0.0.0-20220530194701-151246fd8480 h1:tY5p+Qv0JL4FhF5qI/MsC2GglZ0m3LoRKsYwBwcgEFU=
-github.com/openshift/hypershift v0.0.0-20220530194701-151246fd8480/go.mod h1:yZU2irRqb0kFn+M3X4LHNnzCvY24fgeGzPyHqyWfY5o=
+github.com/openshift/hypershift v0.0.0-20220607131543-f684373220da h1:a1Xo1HNpgs4njtXdt2cskqj8UBlYZQyhGsh+AKIKKfw=
+github.com/openshift/hypershift v0.0.0-20220607131543-f684373220da/go.mod h1:yZU2irRqb0kFn+M3X4LHNnzCvY24fgeGzPyHqyWfY5o=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJc5AZX7/PBEpw=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=


### PR DESCRIPTION
Signed-off-by: Philip Wu <phwu@redhat.com>

<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* Doc indicates local-cluster on MCE could be used as the hypershift management cluster

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  For MCE, local-cluster is not imported by default. Include info on how to import local-cluster

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-1449

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant -->
## Test API/Unit - Success
```script
N/A
```

