### PR TITLE
Add new HD Spec.HostedClusterSet. 

### DIFF
--- a/api/v1alpha1/hypershiftdeployment_types.go
+++ b/api/v1alpha1/hypershiftdeployment_types.go
@@ -126,6 +126,11 @@ type HypershiftDeploymentSpec struct {
 	// +optional
 	NodePools []*HypershiftNodePools `json:"nodePools,omitempty"`
 
+	// HostedManagedClusterSet is the ManagedClusterSet the hosted cluster should belong to.
+	// If omitted, the default is the hosting cluster's cluster set
+	// +optional
+	HostedManagedClusterSet string `json:"hostedManagedClusterSet,omitempty"`
+
 	// Reference to an array of NodePool resources on the HyperShift deployment namespace that will be applied
 	// to the ManagementCluster by ACM,
 	// required if InfraSpec.Configure is false

--- a/config/crd/cluster.open-cluster-management.io_hypershiftdeployments.yaml
+++ b/config/crd/cluster.open-cluster-management.io_hypershiftdeployments.yaml
@@ -1204,6 +1204,11 @@ spec:
                 - services
                 - sshKey
                 type: object
+              hostedManagedClusterSet:
+                description: HostedManagedClusterSet is the ManagedClusterSet the
+                  hosted cluster should belong to. If omitted, the default is the
+                  hosting cluster's cluster set
+                type: string
               hostingCluster:
                 description: HostingCluster only applies to ManifestWork, and specifies
                   which managedCluster's namespace the manifestwork will be applied

--- a/pkg/controllers/manifestwork_test.go
+++ b/pkg/controllers/manifestwork_test.go
@@ -52,22 +52,22 @@ func getHDforManifestWork() *hyd.HypershiftDeployment {
 	return testHD
 }
 
-func getClusterSetBinding(namespace string) *clusterv1beta1.ManagedClusterSetBinding {
+func getClusterSetBinding(namespace, name string) *clusterv1beta1.ManagedClusterSetBinding {
 	return &clusterv1beta1.ManagedClusterSetBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "dev",
+			Name:      name,
 			Namespace: namespace,
 		},
 		Spec: clusterv1beta1.ManagedClusterSetBindingSpec{
-			ClusterSet: "dev",
+			ClusterSet: name,
 		},
 	}
 }
 
-func getClusterSet() *clusterv1beta1.ManagedClusterSet {
+func getClusterSet(name string) *clusterv1beta1.ManagedClusterSet {
 	return &clusterv1beta1.ManagedClusterSet{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "dev",
+			Name: name,
 		},
 		Spec: clusterv1beta1.ManagedClusterSetSpec{},
 	}
@@ -1582,7 +1582,7 @@ func TestValidateSecurityConstraints(t *testing.T) {
 	c := meta.FindStatusCondition(resultHD.Status.Conditions, string(hyd.WorkConfigured))
 	assert.True(t, strings.Contains(c.Message, "a bound ManagedClusterSetBinding is required in namespace"), "when validating namespace needs at least one bound ManagedClusterSetBinding")
 
-	binding := getClusterSetBinding(testHD.Namespace)
+	binding := getClusterSetBinding(testHD.Namespace, "dev")
 	client.Create(ctx, binding)
 	defer client.Delete(ctx, binding)
 
@@ -1630,7 +1630,7 @@ func TestValidateSecurityConstraints(t *testing.T) {
 	c = meta.FindStatusCondition(resultHD.Status.Conditions, string(hyd.WorkConfigured))
 	assert.True(t, strings.Contains(c.Message, "is a member of a ManagedClusterSet"), "when validating HostingCluster needs to be a ManagedCluster that is a member of a ManagedClusterSet")
 
-	clusterSet := getClusterSet()
+	clusterSet := getClusterSet("dev")
 	client.Create(ctx, clusterSet)
 	defer client.Delete(ctx, clusterSet)
 
@@ -1642,6 +1642,40 @@ func TestValidateSecurityConstraints(t *testing.T) {
 	passed, err = hdr.validateSecurityConstraints(ctx, testHD)
 	assert.Nil(t, err, "is nil when validating HypershiftDeploymentReconciler security constraints")
 	assert.True(t, passed, "when validating HostingCluster needs to be a ManagedCluster that is a member of a ManagedClusterSet")
+
+	testHD.Spec.HostedManagedClusterSet = "not-exist-cluster-set"
+	passed, err = hdr.validateSecurityConstraints(ctx, testHD)
+	assert.Nil(t, err, "is nil when validating HypershiftDeploymentReconciler security constraints")
+	assert.False(t, passed, "when validating HostingCluster Spec HostedManagedClusterSet")
+
+	err = client.Get(context.Background(), getNN, &resultHD)
+	assert.Nil(t, err, "is nil when HypershiftDeployment resource is found")
+
+	c = meta.FindStatusCondition(resultHD.Status.Conditions, string(hyd.WorkConfigured))
+	assert.True(t, strings.Contains(c.Message, "ManagedClusterSet is not found"), "when validating HostingCluster Spec HostedManagedClusterSet")
+
+	clusterSet = getClusterSet("qa")
+	client.Create(ctx, clusterSet)
+	defer client.Delete(ctx, clusterSet)
+
+	testHD.Spec.HostedManagedClusterSet = "qa"
+	passed, err = hdr.validateSecurityConstraints(ctx, testHD)
+	assert.Nil(t, err, "is nil when validating HypershiftDeploymentReconciler security constraints")
+	assert.False(t, passed, "when validating HostingCluster Spec HostedManagedClusterSet")
+
+	err = client.Get(context.Background(), getNN, &resultHD)
+	assert.Nil(t, err, "is nil when HypershiftDeployment resource is found")
+
+	c = meta.FindStatusCondition(resultHD.Status.Conditions, string(hyd.WorkConfigured))
+	assert.True(t, strings.Contains(c.Message, "a bound ManagedClusterSetBinding is required"), "when validating HostingCluster Spec HostedManagedClusterSet")
+
+	binding = getClusterSetBinding(testHD.Namespace, "qa")
+	client.Create(ctx, binding)
+	defer client.Delete(ctx, binding)
+
+	passed, err = hdr.validateSecurityConstraints(ctx, testHD)
+	assert.Nil(t, err, "is nil when validating HypershiftDeploymentReconciler security constraints")
+	assert.True(t, passed, "when validating namespace needs at least one bound ManagedClusterSetBinding")
 }
 
 func TestDeleteManifestworkWaitCleanUp(t *testing.T) {
@@ -1672,7 +1706,7 @@ func TestDeleteManifestworkWaitCleanUp(t *testing.T) {
 	assert.Equal(t, workv1.DeletePropagationPolicyTypeSelectivelyOrphan, mw.Spec.DeleteOption.PropagationPolicy,
 		"set selectivelyOrphan and not orphan")
 	mw.Status.Conditions = []metav1.Condition{
-		metav1.Condition{
+		{
 			Type:               string(workv1.WorkAvailable),
 			ObservedGeneration: mw.Generation,
 			Status:             metav1.ConditionTrue,
@@ -1683,6 +1717,9 @@ func TestDeleteManifestworkWaitCleanUp(t *testing.T) {
 	// 2nd pass
 	rqst, err = hdr.deleteManifestworkWaitCleanUp(ctx, testHD)
 	assert.Nil(t, err, "is nil when deleteManifestWorkWaitCleanUp is successful")
+	c := meta.FindStatusCondition(testHD.Status.Conditions, string(hyd.WorkConfigured))
+	assert.True(t, strings.Contains(c.Message, "Removing HypershiftDeployment's manifestwork and related resources"),
+		"delete ManifestWork should set the HypershiftDeployment status condition")
 	assert.EqualValues(t, ctrl.Result{RequeueAfter: 20 * time.Second, Requeue: true}, rqst, "request requeue should be 20s")
 	err = client.Get(ctx, types.NamespacedName{Name: mw.Name, Namespace: mw.Namespace}, mw)
 	assert.True(t, apierrors.IsNotFound(err), "true when ManifestWork is removed")


### PR DESCRIPTION
Add new HD Spec.HostedClusterSet. If populated then validates and sets the newly created managed cluster to that cluserSet

Signed-off-by: Mike Ng <ming@redhat.com>

<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* New optional Spec.HostedClusterSet. If security validation is enabled and the value is populated then check against the value to make sure it exists and passes all the security constraints. If populated newly created managed cluster will use that clusterSet value. 

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  Allow user to set the ManagedClusterSet value of their choice. 

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-1261

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant -->
## Test API/Unit - Success
```script
?   	github.com/stolostron/hypershift-deployment-controller/api/v1alpha1	[no test files]
?   	github.com/stolostron/hypershift-deployment-controller/pkg	[no test files]
ok  	github.com/stolostron/hypershift-deployment-controller/pkg/client	0.063s	coverage: 87.5% of statements
?   	github.com/stolostron/hypershift-deployment-controller/pkg/constant	[no test files]
ok  	github.com/stolostron/hypershift-deployment-controller/pkg/controllers	3.434s	coverage: 80.2% of statements
ok  	github.com/stolostron/hypershift-deployment-controller/pkg/controllers/autoimport	0.131s	coverage: 54.6% of statements
ok  	github.com/stolostron/hypershift-deployment-controller/pkg/helper	0.100s	coverage: 62.5% of statements
ok  	github.com/stolostron/hypershift-deployment-controller/test/integration	30.314s	coverage: [no statements]
```

