### PR TITLE
WIP: ACM-1420, lookup release version for default release image

### DIFF
--- a/pkg/constant/constants.go
+++ b/pkg/constant/constants.go
@@ -3,11 +3,14 @@ package constant
 const (
 	AnnoHypershiftDeployment = "cluster.open-cluster-management.io/hypershiftdeployment"
 
+	AnnoHostingVersion = "hosting.cluster.open-cluster-management.io/initialversion"
+
 	NamespaceNameSeperator = "/"
 
 	ManagedClusterCleanupFinalizer = "hypershiftdeployment.cluster.open-cluster-management.io/managedcluster-cleanup"
 
-	ReleaseImage = "quay.io/openshift-release-dev/ocp-release:4.10.15-x86_64"
+	ReleaseImageUrl = "quay.io/openshift-release-dev/ocp-release:"
+	ReleaseImage    = ReleaseImageUrl + "4.10.15-x86_64"
 
 	// DestroyFinalizer makes sure infrastructure is cleaned up before it is removed
 	DestroyFinalizer = "hypershiftdeployment.cluster.open-cluster-management.io/finalizer"
@@ -23,6 +26,9 @@ const (
 
 	// HostingClusterMissing message
 	HostingClusterMissing = "spec.hostingCluster value is missing"
+
+	// HostingManagedClusterMissing message. The managedCluster is not found
+	HostingManagedClusterMissing = "the managedCluster defined by spec.hostingCluster was not found"
 
 	// CreatedByHypershiftDeployment is an annotation that is used to show ownership via infra-ids
 	CreatedByHypershiftDeployment = "hypershift-deployment.open-cluster-management.io/created-by"

--- a/pkg/controllers/default_resources.go
+++ b/pkg/controllers/default_resources.go
@@ -42,18 +42,6 @@ import (
 
 var resLog = ctrl.Log.WithName("resource-render")
 
-func getReleaseImagePullSpec() string {
-
-	/* TODO: ACM-1420, this comment fixes ACM-14-17
-	defaultVersion, err := version.LookupDefaultOCPVersion()
-	if err != nil {
-		return constant.ReleaseImage
-	}
-	return defaultVersion.PullSpec
-	*/
-	return constant.ReleaseImage
-}
-
 func (r *HypershiftDeploymentReconciler) scaffoldHostedCluster(ctx context.Context, hyd *hypdeployment.HypershiftDeployment) (*unstructured.Unstructured, error) {
 	hostedCluster := &unstructured.Unstructured{}
 	hostedCluster.SetAPIVersion(hyp.GroupVersion.String())
@@ -237,7 +225,7 @@ func scaffoldHostedClusterSpec(hyd *hypdeployment.HypershiftDeployment) {
 				// Defaults for all platforms
 				PullSecret: corev1.LocalObjectReference{Name: hyd.Name + "-pull-secret"},
 				Release: hyp.Release{
-					Image: getReleaseImagePullSpec(), //.DownloadURL,
+					Image: hyd.Annotations[constant.AnnoHostingVersion], //.DownloadURL,
 				},
 				Services: []hyp.ServicePublishingStrategyMapping{},
 			}
@@ -363,13 +351,12 @@ func ScaffoldNodePoolSpec(hyd *hypdeployment.HypershiftDeployment) {
 						Type: hyp.NonePlatform,
 					},
 					Release: hyp.Release{
-						Image: getReleaseImagePullSpec(), //.DownloadURL,,
+						Image: hyd.Annotations[constant.AnnoHostingVersion], //.DownloadURL,,
 					},
 				},
 			},
 		}
 	}
-
 	for _, np := range hyd.Spec.NodePools {
 		if np.Spec.ClusterName != hyd.Name {
 			np.Spec.ClusterName = hyd.Name

--- a/pkg/controllers/hypershiftdeployment_controller_test.go
+++ b/pkg/controllers/hypershiftdeployment_controller_test.go
@@ -153,7 +153,7 @@ func TestScaffoldHostedClusterSpec(t *testing.T) {
 		// Defaults for all platforms
 		PullSecret: corev1.LocalObjectReference{Name: ""},
 		Release: hyp.Release{
-			Image: getReleaseImagePullSpec(), //.DownloadURL,
+			Image: constant.ReleaseImage, //.DownloadURL,
 		},
 		Services: []hyp.ServicePublishingStrategyMapping{},
 	}

--- a/pkg/helper/helpers.go
+++ b/pkg/helper/helpers.go
@@ -5,6 +5,7 @@ import (
 
 	hypdeployment "github.com/stolostron/hypershift-deployment-controller/api/v1alpha1"
 	hydclient "github.com/stolostron/hypershift-deployment-controller/pkg/client"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	clusterv1beta1 "open-cluster-management.io/api/cluster/v1beta1"
@@ -17,6 +18,12 @@ func GetHostingCluster(hyd *hypdeployment.HypershiftDeployment) string {
 	}
 
 	return hyd.Spec.HostingCluster
+}
+
+func GetHostingClusterKey(hyd *hypdeployment.HypershiftDeployment) types.NamespacedName {
+	return types.NamespacedName{
+		Name: GetHostingCluster(hyd),
+	}
 }
 
 func GetHostingNamespace(hyd *hypdeployment.HypershiftDeployment) string {


### PR DESCRIPTION
* Look up the default release image using the version of the Hosting Cluster.
* Add test for new getHostingClusterVersion
* Default to 4.10.15 if we can not find a version
* Use the ManagedCluster.Status.ClusterClaims to find the version.openshift.io

Signed-off-by: Joshua Packer <jpacker@redhat.com>

<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* The 4.11 HostedClusters would fail when auto provisioning as the latest OCP was 4.11 but the hosting cluster is 4.10. Hosting Service Clusters do not support N+1 OCP.

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  To allow the easy step process to provision Hypershift.

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* ACM-1420

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant -->
## Test API/Unit - Success
```script
?       github.com/stolostron/hypershift-deployment-controller/api/v1alpha1     [no test files]
?       github.com/stolostron/hypershift-deployment-controller/pkg      [no test files]
ok      github.com/stolostron/hypershift-deployment-controller/pkg/client       0.021s  coverage: 87.5% of statements
?       github.com/stolostron/hypershift-deployment-controller/pkg/constant     [no test files]
ok      github.com/stolostron/hypershift-deployment-controller/pkg/controllers  0.163s  coverage: 77.6% of statements
ok      github.com/stolostron/hypershift-deployment-controller/pkg/controllers/autoimport       0.030s  coverage: 60.6% of statements
ok      github.com/stolostron/hypershift-deployment-controller/pkg/helper       0.022s  coverage: 60.6% of statements
ok      github.com/stolostron/hypershift-deployment-controller/test/integration 27.818s coverage: [no statements]
```

