### PR TITLE
CRD yamls should match type definition

### DIFF
--- a/config/crd/cluster.open-cluster-management.io_hypershiftdeployments.yaml
+++ b/config/crd/cluster.open-cluster-management.io_hypershiftdeployments.yaml
@@ -724,16 +724,14 @@ spec:
                           running on IBMCloud Power VS Service. This field is immutable.
                           Once set, It can't be changed.
                         properties:
-                          accountID:
-                            description: AccountID is the IBMCloud account id. This
-                              field is immutable. Once set, It can't be changed.
-                            type: string
                           controlPlaneOperatorCreds:
                             description: "ControlPlaneOperatorCreds is a reference
                               to a secret containing cloud credentials with permissions
-                              matching the control-plane-operator policy. This field
-                              is immutable. Once set, It can't be changed. \n TODO(dan):
-                              document the \"control plane operator policy\""
+                              matching the control-plane-operator policy. The secret
+                              should have exactly one key, `credentials`, whose value
+                              is an AWS credentials file. This field is immutable.
+                              Once set, It can't be changed. \n TODO(dan): document
+                              the \"control plane operator policy\""
                             properties:
                               name:
                                 description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
@@ -744,9 +742,11 @@ spec:
                           kubeCloudControllerCreds:
                             description: "KubeCloudControllerCreds is a reference
                               to a secret containing cloud credentials with permissions
-                              matching the cloud controller policy. This field is
-                              immutable. Once set, It can't be changed. \n TODO(dan):
-                              document the \"cloud controller policy\""
+                              matching the cloud controller policy. The secret should
+                              have exactly one key, `credentials`, whose value is
+                              an AWS credentials file. This field is immutable. Once
+                              set, It can't be changed. \n TODO(dan): document the
+                              \"cloud controller policy\""
                             properties:
                               name:
                                 description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
@@ -757,9 +757,11 @@ spec:
                           nodePoolManagementCreds:
                             description: "NodePoolManagementCreds is a reference to
                               a secret containing cloud credentials with permissions
-                              matching the node pool management policy. This field
-                              is immutable. Once set, It can't be changed. \n TODO(dan):
-                              document the \"node pool management policy\""
+                              matching the node pool management policy. The secret
+                              should have exactly one key, `credentials`, whose value
+                              is an AWS credentials file. This field is immutable.
+                              Once set, It can't be changed. \n TODO(dan): document
+                              the \"node pool management policy\""
                             properties:
                               name:
                                 description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
@@ -838,7 +840,6 @@ spec:
                               Once set, It can't be changed.
                             type: string
                         required:
-                        - accountID
                         - controlPlaneOperatorCreds
                         - kubeCloudControllerCreds
                         - nodePoolManagementCreds

--- a/config/crd/hypershift.openshift.io_hostedclusters.yaml
+++ b/config/crd/hypershift.openshift.io_hostedclusters.yaml
@@ -663,16 +663,13 @@ spec:
                       on IBMCloud Power VS Service. This field is immutable. Once
                       set, It can't be changed.
                     properties:
-                      accountID:
-                        description: AccountID is the IBMCloud account id. This field
-                          is immutable. Once set, It can't be changed.
-                        type: string
                       controlPlaneOperatorCreds:
                         description: "ControlPlaneOperatorCreds is a reference to
                           a secret containing cloud credentials with permissions matching
-                          the control-plane-operator policy. This field is immutable.
-                          Once set, It can't be changed. \n TODO(dan): document the
-                          \"control plane operator policy\""
+                          the control-plane-operator policy. The secret should have
+                          exactly one key, `credentials`, whose value is an AWS credentials
+                          file. This field is immutable. Once set, It can't be changed.
+                          \n TODO(dan): document the \"control plane operator policy\""
                         properties:
                           name:
                             description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
@@ -682,9 +679,10 @@ spec:
                       kubeCloudControllerCreds:
                         description: "KubeCloudControllerCreds is a reference to a
                           secret containing cloud credentials with permissions matching
-                          the cloud controller policy. This field is immutable. Once
-                          set, It can't be changed. \n TODO(dan): document the \"cloud
-                          controller policy\""
+                          the cloud controller policy. The secret should have exactly
+                          one key, `credentials`, whose value is an AWS credentials
+                          file. This field is immutable. Once set, It can't be changed.
+                          \n TODO(dan): document the \"cloud controller policy\""
                         properties:
                           name:
                             description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
@@ -694,9 +692,10 @@ spec:
                       nodePoolManagementCreds:
                         description: "NodePoolManagementCreds is a reference to a
                           secret containing cloud credentials with permissions matching
-                          the node pool management policy. This field is immutable.
-                          Once set, It can't be changed. \n TODO(dan): document the
-                          \"node pool management policy\""
+                          the node pool management policy. The secret should have
+                          exactly one key, `credentials`, whose value is an AWS credentials
+                          file. This field is immutable. Once set, It can't be changed.
+                          \n TODO(dan): document the \"node pool management policy\""
                         properties:
                           name:
                             description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
@@ -773,7 +772,6 @@ spec:
                           set, It can't be changed.
                         type: string
                     required:
-                    - accountID
                     - controlPlaneOperatorCreds
                     - kubeCloudControllerCreds
                     - nodePoolManagementCreds


### PR DESCRIPTION
Signed-off-by: Mike Ng <ming@redhat.com>

<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* update CRD after running `make manifests`

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  CRD needs to match our type go definition.

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* NA

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant -->
## Test API/Unit - Success
```script
?   	github.com/stolostron/hypershift-deployment-controller/api/v1alpha1	[no test files]
?   	github.com/stolostron/hypershift-deployment-controller/pkg	[no test files]
ok  	github.com/stolostron/hypershift-deployment-controller/pkg/client	0.062s	coverage: 87.5% of statements
?   	github.com/stolostron/hypershift-deployment-controller/pkg/constant	[no test files]
ok  	github.com/stolostron/hypershift-deployment-controller/pkg/controllers	3.239s	coverage: 80.1% of statements
ok  	github.com/stolostron/hypershift-deployment-controller/pkg/controllers/autoimport	0.042s	coverage: 60.6% of statements
ok  	github.com/stolostron/hypershift-deployment-controller/pkg/helper	0.027s	coverage: 62.5% of statements
ok  	github.com/stolostron/hypershift-deployment-controller/test/integration	28.737s	coverage: [no statements]
```

