### PR TITLE
support private mode hosted clusters

### DIFF
--- a/pkg/controllers/autoimport/autoimport_controller.go
+++ b/pkg/controllers/autoimport/autoimport_controller.go
@@ -242,35 +242,6 @@ func ensureManagedCluster(r *Reconciler, hydNamespaceName types.NamespacedName,
 	return &mc, nil
 }
 
-func ensureAutoImportSecret(r *Reconciler, managedClusterName string, kubeSecret *corev1.Secret) error {
-	log := r.Log.WithValues("managedClusterName", managedClusterName)
-	ctx := context.Background()
-
-	var secret corev1.Secret
-	/* #nosec */
-	secretName := "auto-import-secret"
-	err := r.Get(ctx, types.NamespacedName{Namespace: managedClusterName, Name: secretName}, &secret)
-	if k8serrors.IsNotFound(err) {
-
-		log.V(INFO).Info("Create a new auto import secret resource")
-		secret.Name = secretName
-		secret.Namespace = managedClusterName
-		secret.Data = kubeSecret.Data
-
-		if err := r.Create(ctx, &secret, &client.CreateOptions{}); err != nil {
-			log.V(ERROR).Info("Could not create auto import secret", "error", err)
-			return err
-		}
-		return nil
-	}
-	if err != nil {
-		log.V(WARN).Info("Error when attempting to retreive the auto import secret", "error", err)
-		return err
-	}
-
-	return nil
-}
-
 func ensureCreateManagedClusterAnnotationFalse(r *Reconciler, hyd *hypdeployment.HypershiftDeployment) error {
 	if createmc, ok := hyd.Annotations[createManagedClusterAnnotation]; ok && createmc == "false" {
 		return nil

--- a/pkg/controllers/autoimport/autoimport_controller.go
+++ b/pkg/controllers/autoimport/autoimport_controller.go
@@ -128,9 +128,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			log.V(INFO).Info("Wait for the hosted cluster kubeconfig to be created", "secret", secretNamespaceName.String())
 			return ctrl.Result{}, nil
 		}
-		if err := ensureAutoImportSecret(r, managedClusterName, &kubeconfig); err != nil {
-			return ctrl.Result{}, err
-		}
 	}
 
 	// Make sure we don't create the ManagedCluster if it is detached

--- a/pkg/controllers/autoimport/autoimport_controller_test.go
+++ b/pkg/controllers/autoimport/autoimport_controller_test.go
@@ -185,23 +185,6 @@ func TestReconcileCreate(t *testing.T) {
 			},
 		},
 		{
-			name:              "create managed cluster and secret",
-			kubesecret:        GetHostedClusterKubeconfig(HYD_NAMESPACE, helper.HostedKubeconfigName(hyd)),
-			hyd:               hyd.DeepCopy(),
-			managementCluster: managementCluster.DeepCopy(),
-			validateActions: func(t *testing.T, ctx context.Context, client crclient.Client) {
-				var mc mcv1.ManagedCluster
-				err := client.Get(ctx, getNamespaceName("", helper.ManagedClusterName(hyd)), &mc)
-				assert.Nil(t, err, "managedCluster resource is retrieved")
-
-				var autoImportSecret corev1.Secret
-				err = client.Get(ctx, getNamespaceName(mc.Name, "auto-import-secret"), &autoImportSecret)
-				assert.Nil(t, err, "secret resource is retrieved")
-
-				assertAnnoCreateMCFalse(t, ctx, client)
-			},
-		},
-		{
 			name:              "should not create managed cluster, annotation false",
 			kubesecret:        GetHostedClusterKubeconfig(HYD_NAMESPACE, helper.HostedKubeconfigName(hyd)),
 			hyd:               setAnnotationHYD(hyd.DeepCopy(), map[string]string{createManagedClusterAnnotation: "false"}),


### PR DESCRIPTION
Signed-off-by: Roke Jung <roke@redhat.com>

<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
*  Create `external-managed-kubeconfig` with internal hosted cluster kube API server URL so in both private and public modes, the registration agent can connect to the hosted cluster's API server for managed cluster registration.
* Do not create auto-import kubeconfig secret in the hosting cluster namespace on the hub
* https://github.com/stolostron/backlog/issues/23514#issuecomment-1157738028

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  To support private mode hosted clusters

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://github.com/stolostron/backlog/issues/23514
* https://issues.redhat.com/browse/ACM-1466

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script
Running tool: /usr/local/go/bin/go test -timeout 30s -run ^(TestReconcileCreate|TestReconcileDelete)$ github.com/stolostron/hypershift-deployment-controller/pkg/controllers/autoimport

ok  	github.com/stolostron/hypershift-deployment-controller/pkg/controllers/autoimport	0.601s
```

Deployed an AWS hosted cluster successfully with https://github.com/stolostron/hypershift-addon-operator/pull/56 and the server URL in `klusterlet-rj-0620a-tkh4g/external-managed-kubeconfig` was set as the following.

```
    server: https://kube-apiserver.clusters-rj-0620a.svc.cluster.local:6443
```