### PR TITLE
re-enable crd compare check

### DIFF
--- a/test/crd-compare.sh
+++ b/test/crd-compare.sh
@@ -7,9 +7,6 @@ tmpCrd=$(mktemp)
 COMMIT_SHA=`cat go.mod | grep github.com/openshift/hypershift | sed -En 's/.* v.*-//p'`
 echo Using SHA ${COMMIT_SHA}
 
-printf "*****\n  Skip checking HostedCluster CRD temporarily\n"
-exit 0
-
 printf "*****\n  Checking HostedCluster CRD\n"
 
 curl --silent https://raw.githubusercontent.com/openshift/hypershift/${COMMIT_SHA}/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml --output ${curCrd}


### PR DESCRIPTION
Signed-off-by: Mike Ng <ming@redhat.com>

<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* the skip crd compare check was disabled. This change is to re-enable it.

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  Ensure CRD consistency

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* Not applicable

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant -->
## Test API/Unit - Success
```script
Not applicable
```

/assign @zhujian7 
/assign @jnpacker 
/assign @rokej 
/assign @philipwu08 