### PR TITLE
Add support for CUSTOM ManagedCluster names outside HypershiftDeploy.

### DIFF
--- a/pkg/constant/constants.go
+++ b/pkg/constant/constants.go
@@ -3,6 +3,8 @@ package constant
 const (
 	AnnoHypershiftDeployment = "cluster.open-cluster-management.io/hypershiftdeployment"
 
+	ManagedClusterAnnoKey = "cluster.open-cluster-management.io/managedcluster-name"
+
 	NamespaceNameSeperator = "/"
 
 	ManagedClusterCleanupFinalizer = "hypershiftdeployment.cluster.open-cluster-management.io/managedcluster-cleanup"

--- a/pkg/controllers/autoimport/autoimport_controller.go
+++ b/pkg/controllers/autoimport/autoimport_controller.go
@@ -84,12 +84,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, nil
 	}
 
-	if len(hyd.Spec.InfraID) == 0 {
-		log.V(INFO).Info("Resource hypershift spec infraID is empty")
-		return ctrl.Result{}, nil
-	}
-
-	log.V(INFO).Info("Hypershift Deployment info", "InfraID", hyd.Spec.InfraID,
+	log.V(INFO).Info("Hypershift Deployment info", "Name", hyd.Name,
 		"hostingNamespace", hyd.Spec.HostingNamespace, "hostingCluster", hyd.Spec.HostingCluster)
 
 	managedClusterName := helper.ManagedClusterName(&hyd)

--- a/pkg/controllers/aws_infra.go
+++ b/pkg/controllers/aws_infra.go
@@ -116,12 +116,9 @@ func (r *HypershiftDeploymentReconciler) createAWSInfra(hyd *hypdeployment.Hyper
 			hyd.Spec.HostedClusterSpec.Platform.AWS.RolesRef.IngressARN = iamOut.Roles.IngressARN
 			hyd.Spec.HostedClusterSpec.Platform.AWS.RolesRef.NetworkARN = iamOut.Roles.NetworkARN
 			hyd.Spec.HostedClusterSpec.Platform.AWS.RolesRef.StorageARN = iamOut.Roles.StorageARN
-			hyd.Spec.Credentials = &hypdeployment.CredentialARNs{
-				AWS: &hypdeployment.AWSCredentials{
-					ControlPlaneOperatorARN: iamOut.Roles.ControlPlaneOperatorARN,
-					KubeCloudControllerARN:  iamOut.Roles.KubeCloudControllerARN,
-					NodePoolManagementARN:   iamOut.Roles.NodePoolManagementARN,
-				}}
+			hyd.Spec.HostedClusterSpec.Platform.AWS.RolesRef.ControlPlaneOperatorARN = iamOut.Roles.ControlPlaneOperatorARN
+			hyd.Spec.HostedClusterSpec.Platform.AWS.RolesRef.KubeCloudControllerARN = iamOut.Roles.KubeCloudControllerARN
+			hyd.Spec.HostedClusterSpec.Platform.AWS.RolesRef.NodePoolManagementARN = iamOut.Roles.NodePoolManagementARN
 			if err := r.patchHypershiftDeploymentResource(hyd); err != nil {
 				return ctrl.Result{},
 					r.updateStatusConditionsOnChange(hyd, hypdeployment.PlatformIAMConfigured,
@@ -144,14 +141,6 @@ func (r *HypershiftDeploymentReconciler) createAWSInfra(hyd *hypdeployment.Hyper
 		}
 	}
 
-	if hyd.Spec.HostedClusterSpec.Platform.Type == "AWS" && (hyd.Spec.Credentials == nil || hyd.Spec.Credentials.AWS == nil) {
-		return ctrl.Result{},
-			r.updateStatusConditionsOnChange(hyd,
-				hypdeployment.PlatformIAMConfigured,
-				metav1.ConditionFalse,
-				"Missing Spec.Credentials.AWS",
-				hypdeployment.MisConfiguredReason)
-	}
 	return ctrl.Result{}, nil
 }
 

--- a/pkg/controllers/aws_infra_test.go
+++ b/pkg/controllers/aws_infra_test.go
@@ -289,7 +289,13 @@ func TestCreateAwsInfraIAMMisConfigured(t *testing.T) {
 
 	c := meta.FindStatusCondition(hyd.Status.Conditions, string(hypdeployment.PlatformIAMConfigured))
 	assert.NotNil(t, c, "not nil, when condition is found")
-	assert.Equal(t, metav1.ConditionFalse, c.Status, "false, when removing iam infrastructure")
-	assert.Equal(t, hypdeployment.MisConfiguredReason, c.Reason, "reason is Removing")
-	assert.Equal(t, "Missing Spec.Credentials.AWS", c.Message)
+	assert.Equal(t, metav1.ConditionTrue, c.Status, "true, when removing iam infrastructure")
+	assert.Equal(t, hypdeployment.ConfiguredAsExpectedReason, c.Reason, "reason is all is good")
+	assert.Equal(t, "arn:aws:iam::012345678910:role/hypershift-test-abcde-control-plane-operator",
+		hyd.Spec.HostedClusterSpec.Platform.AWS.RolesRef.ControlPlaneOperatorARN)
+	assert.Equal(t, "arn:aws:iam::012345678910:role/hypershift-test-abcde-cloud-controller",
+		hyd.Spec.HostedClusterSpec.Platform.AWS.RolesRef.KubeCloudControllerARN)
+	assert.Equal(t, "arn:aws:iam::012345678910:role/hypershift-test-abcde-node-pool",
+		hyd.Spec.HostedClusterSpec.Platform.AWS.RolesRef.NodePoolManagementARN)
+
 }

--- a/pkg/controllers/default_resources.go
+++ b/pkg/controllers/default_resources.go
@@ -61,6 +61,7 @@ func (r *HypershiftDeploymentReconciler) scaffoldHostedCluster(ctx context.Conte
 	hostedCluster.SetNamespace(helper.GetHostingNamespace(hyd))
 	hostedCluster.SetAnnotations(map[string]string{
 		constant.AnnoHypershiftDeployment: fmt.Sprintf("%s/%s", hyd.Namespace, hyd.Name),
+		constant.ManagedClusterAnnoKey:    hyd.Name,
 	})
 
 	if !hyd.Spec.Infrastructure.Configure && len(hyd.Spec.HostedClusterRef.Name) != 0 {
@@ -178,15 +179,6 @@ func ScaffoldAWSHostedClusterSpec(hyd *hypdeployment.HypershiftDeployment, infra
 	aws := hyd.Spec.HostedClusterSpec.Platform.AWS.DeepCopy()
 	if aws.Region == "" {
 		aws.Region = hyd.Spec.Infrastructure.Platform.AWS.Region
-	}
-	if aws.ControlPlaneOperatorCreds.Name == "" {
-		aws.ControlPlaneOperatorCreds.Name = hyd.Name + "-cpo-creds"
-	}
-	if aws.KubeCloudControllerCreds.Name == "" {
-		aws.KubeCloudControllerCreds.Name = hyd.Name + "-cloud-ctrl-creds"
-	}
-	if aws.NodePoolManagementCreds.Name == "" {
-		aws.NodePoolManagementCreds.Name = hyd.Name + "-node-mgmt-creds"
 	}
 	if aws.ResourceTags == nil {
 		aws.ResourceTags = []hyp.AWSResourceTag{}
@@ -475,7 +467,7 @@ func ScaffoldAWSSecrets(hyd *hypdeployment.HypershiftDeployment, hc *hyp.HostedC
 	if hyd.Spec.Credentials != nil && hyd.Spec.Credentials.AWS != nil {
 		secrets = append(
 			secrets,
-			//These ObjectRef.Name's will always be set by this point.
+			//This is being deprecated
 			buildAWSCreds(hc.Spec.Platform.AWS.ControlPlaneOperatorCreds.Name, hyd.Spec.Credentials.AWS.ControlPlaneOperatorARN),
 			buildAWSCreds(hc.Spec.Platform.AWS.KubeCloudControllerCreds.Name, hyd.Spec.Credentials.AWS.KubeCloudControllerARN),
 			buildAWSCreds(hc.Spec.Platform.AWS.NodePoolManagementCreds.Name, hyd.Spec.Credentials.AWS.NodePoolManagementARN),

--- a/pkg/controllers/manifestwork.go
+++ b/pkg/controllers/manifestwork.go
@@ -336,14 +336,6 @@ func (r *HypershiftDeploymentReconciler) createOrUpdateMainfestwork(ctx context.
 
 	mwCfg := enableManifestStatusFeedback(m, hyd)
 
-	// This is a special check to make sure these values are provided as they are Not part of the standard
-	// HostedClusterSpec
-	if hyd.Spec.HostedClusterSpec != nil && hyd.Spec.HostedClusterSpec.Platform.AWS != nil &&
-		(hyd.Spec.Credentials == nil || hyd.Spec.Credentials.AWS == nil) {
-		r.Log.Error(errors.New("hyd.Spec.Credentials.AWS == nil"), "missing IAM configuration")
-		return ctrl.Result{}, r.updateStatusConditionsOnChange(hyd, hypdeployment.PlatformIAMConfigured, metav1.ConditionFalse, "Missing Spec.Crednetials.AWS.* platform IAM", hypdeployment.MisConfiguredReason)
-	}
-
 	inHyd := hyd.DeepCopy()
 	// if the manifestwork is created, then move the status to hypershiftDeployment
 	if err := r.Get(ctx, getManifestWorkKey(hyd), m); err == nil {

--- a/pkg/controllers/manifestwork_test.go
+++ b/pkg/controllers/manifestwork_test.go
@@ -240,24 +240,6 @@ func TestManifestWorkFlowBaseCase(t *testing.T) {
 			GroupVersionKind: schema.GroupVersionKind{
 				Group: "", Version: "v1", Kind: "Secret"},
 			NamespacedName: types.NamespacedName{
-				Name: "test1-node-mgmt-creds", Namespace: helper.GetHostingNamespace(testHD)}}: true,
-
-		{
-			GroupVersionKind: schema.GroupVersionKind{
-				Group: "", Version: "v1", Kind: "Secret"},
-			NamespacedName: types.NamespacedName{
-				Name: "test1-cpo-creds", Namespace: helper.GetHostingNamespace(testHD)}}: true,
-
-		{
-			GroupVersionKind: schema.GroupVersionKind{
-				Group: "", Version: "v1", Kind: "Secret"},
-			NamespacedName: types.NamespacedName{
-				Name: "test1-node-mgmt-creds", Namespace: helper.GetHostingNamespace(testHD)}}: true,
-
-		{
-			GroupVersionKind: schema.GroupVersionKind{
-				Group: "", Version: "v1", Kind: "Secret"},
-			NamespacedName: types.NamespacedName{
 				Name: "test1-pull-secret", Namespace: helper.GetHostingNamespace(testHD)}}: true,
 	}
 

--- a/pkg/helper/helpers.go
+++ b/pkg/helper/helpers.go
@@ -27,7 +27,7 @@ func GetHostingNamespace(hyd *hypdeployment.HypershiftDeployment) string {
 }
 
 func ManagedClusterName(hyd *hypdeployment.HypershiftDeployment) string {
-	return hyd.Spec.InfraID
+	return hyd.Name
 }
 
 // TODO(zhujian7) get this from hyd.Status.Kubeconfig

--- a/test/integration/manifest_test.go
+++ b/test/integration/manifest_test.go
@@ -360,9 +360,9 @@ var _ = ginkgo.Describe("Manifest Work", func() {
 					return false
 				}
 
-				// Namespace + HostedCluster + NodePool + pullSecret + 3 awsArnSecrets + etcd encryption secret
-				// Changed from 8 to 9 because the fake infraCreator returns 2 zones for AWS. This creates 2 nodepools
-				if len(manifestwork.Spec.Workload.Manifests) != 9 {
+				// Namespace + HostedCluster + NodePool + pullSecret + 3 awsArnSecrets(removed) + etcd encryption secret
+				// Changed from 9 to 6 because the fake infraCreator no longer creates awsArnSecrets
+				if len(manifestwork.Spec.Workload.Manifests) != 6 {
 					return false
 				}
 


### PR DESCRIPTION
Signed-off-by: Joshua Packer <jpacker@redhat.com>

<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* Add support for CUSTOM ManagedCluster names
* Support the original ManagedCluster.Name = HostedCluster.Spec.InfraId (ServiceDelivery & BM Agent UI)
* Support HypershiftDeployment creates ManagedCluster with HypershiftDeployment.Name
* Make sure not to affect BareMetal Agent and ServiceDelivery with this change
* This fixes bugzilla 2114008 which shows two copies of the cluster in the 2.6 UI

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  So that we don't see two copies of the Hypershift cluster in the UI

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://github.com/stolostron/backlog/issues/24783
* https://bugzilla.redhat.com/show_bug.cgi?id=2114008

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant -->
## Test API/Unit - Success
```script
?       github.com/stolostron/hypershift-deployment-controller/api/v1alpha1     [no test files]
?       github.com/stolostron/hypershift-deployment-controller/pkg      [no test files]
ok      github.com/stolostron/hypershift-deployment-controller/pkg/client       0.022s  coverage: 87.5% of statements
?       github.com/stolostron/hypershift-deployment-controller/pkg/constant     [no test files]
ok      github.com/stolostron/hypershift-deployment-controller/pkg/controllers  1.894s  coverage: 80.9% of statements
ok      github.com/stolostron/hypershift-deployment-controller/pkg/controllers/autoimport       0.034s  coverage: 62.7% of statements
ok      github.com/stolostron/hypershift-deployment-controller/pkg/helper       0.030s  coverage: 62.5% of statements
```

