### PR TITLE
remove the namespace since the mce is clusterscope resources

### DIFF
--- a/docs/provision_hypershift_clusters_by_mce.md
+++ b/docs/provision_hypershift_clusters_by_mce.md
@@ -28,7 +28,7 @@ true
 If the value is `false`, make sure to set it true, and don't forget to change `mce-instance-name` to the name of your multicluster-engine instance:
 
 ```bash
-$ oc patch mce <mce-instance-name> -n open-cluster-management --type=json -p='[{"op": "add", "path": "/spec/overrides/components/-","value":{"name":"hypershift-preview","enabled":true}}]'
+$ oc patch mce <mce-instance-name> --type=json -p='[{"op": "add", "path": "/spec/overrides/components/-","value":{"name":"hypershift-preview","enabled":true}}]'
 ```
 
 ## Turn one of the managed clusters into the HyperShift management cluster


### PR DESCRIPTION
Signed-off-by: hchenxa <huichen@redhat.com>

<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* the MCE was cluster scope resources, so when update the MCE CR, did not need the namespace

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* 

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant -->
## Test API/Unit - Success
```script

```

