### PR TITLE
Fix AWS Infra & IAM destroy logging nil pointer

### DIFF
--- a/pkg/controllers/infra_interface.go
+++ b/pkg/controllers/infra_interface.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/go-logr/logr"
 	"github.com/openshift/hypershift/api/fixtures"
@@ -71,6 +72,7 @@ func (h *DefaultInfraHandler) AwsInfraDestroyer(awsKey, awsSecretKey, region, in
 		InfraID:      infraID,
 		Name:         name,
 		BaseDomain:   baseDomain,
+		Log:          log.FromContext(context.Background()),
 	}
 	return o.DestroyInfra
 }
@@ -99,6 +101,7 @@ func (h *DefaultInfraHandler) AwsIAMDestroyer(awsKey, awsSecretKey, region, infr
 		AWSKey:       awsKey,
 		AWSSecretKey: awsSecretKey,
 		InfraID:      infraID,
+		Log:          log.FromContext(context.Background()),
 	}
 
 	return iamOpt.DestroyIAM


### PR DESCRIPTION
Signed-off-by: Joshua Packer <jpacker@redhat.com>

<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* Destroy/Delete for AWS was failing with NIL reference panic

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  This blocked AWS cleanup

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-1569

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant -->
## Test API/Unit - Success
```script
?       github.com/stolostron/hypershift-deployment-controller/api/v1alpha1     [no test files]
?       github.com/stolostron/hypershift-deployment-controller/pkg      [no test files]
ok      github.com/stolostron/hypershift-deployment-controller/pkg/client       0.063s  coverage: 87.5% of statements
?       github.com/stolostron/hypershift-deployment-controller/pkg/constant     [no test files]
ok      github.com/stolostron/hypershift-deployment-controller/pkg/controllers  1.919s  coverage: 80.9% of statements
ok      github.com/stolostron/hypershift-deployment-controller/pkg/controllers/autoimport       0.036s  coverage: 62.7% of statements
ok      github.com/stolostron/hypershift-deployment-controller/pkg/helper       0.033s  coverage: 62.5% of statements
ok      github.com/stolostron/hypershift-deployment-controller/test/integration 29.341s coverage: [no statements]
```

