### PR TITLE
Add note about the required role allowing capi-provider-agent to list and update agents on another namespace from hypershift management

### DIFF
--- a/docs/provision_hypershift_clusters_by_mce.md
+++ b/docs/provision_hypershift_clusters_by_mce.md
@@ -291,6 +291,26 @@ spec:
 EOF
 ```
 
+**NOTE**: If you wish to use `Agents` from a namespace that isn't the ${hypershift-management-cluster} namespace, you must create a role for capi-provider-agent in that namespace (this is the same namespace as specified in the HypershiftDeployment Spec `spec.platform.agent.agentNamespace`).
+~~~sh
+envsubst <<"EOF" | oc apply -f -
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: capi-provider-role
+  namespace: ${AGENT_NS}
+rules:
+- apiGroups:
+  - agent-install.openshift.io
+  resources:
+  - agents
+  verbs:
+  - '*'
+EOF
+~~~
+
+
 ## Access the hosted cluster
 
 The access secrets are stored in the {hypershift-management-cluster} namespace.


### PR DESCRIPTION
<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
*  Updated docs Add note about the required role allowing capi-provider-agent to list and update agents on another namespace from hypershift management

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  Adding hosts using the agent platform would fail without itmake 

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* 

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant -->
## Test API/Unit - Success
```script
?   	github.com/stolostron/hypershift-deployment-controller/api/v1alpha1	[no test files]
?   	github.com/stolostron/hypershift-deployment-controller/pkg	[no test files]
ok  	github.com/stolostron/hypershift-deployment-controller/pkg/client	0.090s	coverage: 87.5% of statements
?   	github.com/stolostron/hypershift-deployment-controller/pkg/constant	[no test files]
ok  	github.com/stolostron/hypershift-deployment-controller/pkg/controllers	9.718s	coverage: 80.9% of statements
ok  	github.com/stolostron/hypershift-deployment-controller/pkg/controllers/autoimport	0.183s	coverage: 62.7% of statements
ok  	github.com/stolostron/hypershift-deployment-controller/pkg/helper	0.119s	coverage: 62.5% of statements
ok  	github.com/stolostron/hypershift-deployment-controller/test/integration	27.716s	coverage: [no statements]

```

