### PR TITLE
Mce21 default release image

### DIFF
--- a/docs/provision_hypershift_clusters_by_mce.md
+++ b/docs/provision_hypershift_clusters_by_mce.md
@@ -90,7 +90,7 @@ $ oc create secret generic hypershift-operator-private-link-credentials --from-l
 ```bash
 $ oc label secret hypershift-operator-private-link-credentials -n <managed-cluster-used-as-hosting-service-cluster> cluster.open-cluster-management.io/backup=true
 ```
-**Enable on a HostedCluster**
+##### Enable on a HostedCluster
 
 Set the following parameter in HypershiftDeployment, when creating a cluster:
 ```
@@ -124,7 +124,7 @@ Add the special label to the `hypershift-operator-external-dns-credentials` secr
 $ oc label secret hypershift-operator-external-dns-credentials -n <managed-cluster-used-as-hosting-service-cluster> cluster.open-cluster-management.io/backup=true
 ```
 
-**Enable on a HostedCluster**
+##### Enable on a HostedCluster
 
 Set the following parameter in HypershiftDeployment, when creating a cluster:
 ```

--- a/docs/provision_hypershift_clusters_by_mce.md
+++ b/docs/provision_hypershift_clusters_by_mce.md
@@ -1,6 +1,26 @@
 # Provision Hypershift Clusters by MCE
 
-The multicluster-engine(MCE) has been installed and at least one OCP managed cluster. We will make this OCP managed cluster a hypershift management cluster. It is possible to use the hub cluster to act as a hypershift management cluster, however, this requires importing the hub cluster as an OCP managed cluster called `local-cluster`:
+Configuring hosted control planes requires a hosting service cluster and a hosted cluster. By deploying the HyperShift operator on an existing cluster, you can make that cluster into a hosting service cluster and start the creation of the hosted cluster. 
+
+Hosted control planes is a Technology Preview feature, so the related components are disabled by default. Enable the feature by editing the `multiclusterengine` custom resource to set the `spec.overrides.components[?(@.name=='hypershift-preview')].enabled` to `true`. 
+
+Enter the following command to ensure that the hosted control planes feature is enabled:
+
+```bash
+oc patch mce multiclusterengine-sample --type=merge -p '{"spec":{"overrides":{"components":[{"name":"hypershift-preview","enabled": true}]}}}'
+```
+
+## Configuring the hosting service cluster
+
+You can deploy hosted control planes by configuring an existing cluster to function as a hosting service cluster. The hosting service cluster is the OCP cluster where the control planes are hosted, and can be the hub cluster or one of the OCP managed clusters. In this section, we will use hypershift-addon to install a HyperShift operator to one of the managed clusters to make it a hosting cluster.
+
+### Prerequisites
+
+You must have the following prerequisites to configure a hosting service cluster: 
+
+- Multicluster engine operator (MCE) installed on OCP cluster.
+
+- MCE has at least one managed OCP cluster. We will make this OCP managed cluster a hypershift management cluster. It is possible to use the MCE hub cluster as a hypershift management cluster. This requires importing the hub cluster as an OCP managed cluster called `local-cluster`:
 
 ```bash
 $ oc apply -f - <<EOF
@@ -16,244 +36,257 @@ spec:
 EOF
 ```
 
-## Enable the Hosted Control Planes related components on the hub cluster
+### Configuring the hosting service cluster
 
-Because Hosted Control Planes is a TP feature, the related components are disabled by default. We should enable it by editing the `multiclusterengine` resource to set the `spec.overrides.components[?(@.name=='hypershift-preview')].enabled` to `true`
+Complete the following steps on the cluster where the multicluster engine operator is installed to enable an {ocp-short} managed cluster as a hosting service cluster:
+
+1. If you plan to provision hosted clusters on the AWS platform, create an OIDC s3 credentials secret for the HyperShift operator, and name it `hypershift-operator-oidc-provider-s3-credentials`. It should reside in managed cluster namespace (i.e., the namespace of the managed cluster that will be used as the hosting service cluster). If you used `local-cluster`, then create the secret in the `local-cluster` namespace
+
+The secret must contain 3 fields:
+
+- `bucket`: An S3 bucket with public access to host OIDC discovery documents for your HyperShift clusters
+- `credentials`: A reference to a file that contains the credentials of the `default` profile that can access the bucket. By default, HyperShift only uses the `default` profile to operate the `bucket`.
+- `region`: Region of the S3 bucket
+
+See [Getting started](https://hypershift-docs.netlify.app/getting-started). in the HyperShift documentation for more information about the secret. The following example shows a sample AWS secret creation CLI template:
 
 ```bash
-$ oc get mce multiclusterengine-sample -ojsonpath="{.spec.overrides.components[?(@.name=='hypershift-preview')].enabled}"
-true
+$ oc create secret generic hypershift-operator-oidc-provider-s3-credentials --from-file=credentials=$HOME/.aws/credentials --from-literal=bucket=<s3-bucket-for-hypershift> --from-literal=region=<region> -n <managed-cluster-used-as-hosting-service-cluster>
 ```
 
-If the value is `false`, make sure to set it true, and don't forget to change `mce-instance-name` to the name of your multicluster-engine instance:
+**Note:** Disaster recovery backup for the secret is not automatically enabled. Run the following command to add the label that enables the `hypershift-operator-oidc-provider-s3-credentials` secret to be backed up for disaster recovery:
 
 ```bash
-$ oc patch mce <mce-instance-name> -n open-cluster-management --type=json -p='[{"op": "add", "path": "/spec/overrides/components/-","value":{"name":"hypershift-preview","enabled":true}}]'
+$ oc label secret hypershift-operator-oidc-provider-s3-credentials -n <managed-cluster-used-as-hosting-service-cluster> cluster.open-cluster-management.io/backup=true
 ```
 
-## Turn one of the managed clusters into the HyperShift management cluster
+#### Enabling AWS Private Link
 
-We call the cluster with the HyperShift operator installed as the hosting service cluster (in HyperShift project terminology, it is called the management cluster). In this section, we will use hypershift-addon to install a HyperShift operator to one of the managed clusters. This step is only needed **once**, not needed for creating more clusters afterwards.
+If you plan to provision hosted clusters on the AWS platform with Private Link, create an AWS credential secret for the HyperShift operator, and name it `hypershift-operator-private-link-credentials`. It should reside in the managed cluster namespace (i.e., the namespace of the managed cluster that will be used as the hosting service cluster). If you used `local-cluster`, then create the secret in the `local-cluster` namespace
 
-Before creating the add-on, we need to make sure to provide the details of the s3 bucket where HyperShift will be storing OIDC discovery information. The s3 bucket is a pre-req for the installation
+Follow the instructions here (steps 1-5): [Deploy AWS private clusters](https://hypershift-docs.netlify.app/how-to/aws/deploy-aws-private-clusters/)
 
-1. If you plan to provision hosted clusters on the AWS platform, create an OIDC s3 credential secret for the HyperShift operator, and name it `hypershift-operator-oidc-provider-s3-credentials`. It should reside in the managed cluster namespace (i.e., the namespace of the managed cluster that will be used as the hosting service cluster). If you used `local-cluster`, then create the secret in the `local-cluster` namespace
+Instructions result in the following AWS resources:
 
-    The secret must contain 3 fields:
+* Create an IAM policy in AWS
+* Create an IAM user for the Hypershift operator to use
+* Attach the IAM policy to the IAM user
+* Create an IAM access key for the user, use the access key and secret in the next section
 
-    - `bucket`: An S3 bucket with public access to host OIDC discovery documents for your HyperShift clusters
-    - `credentials`: Credentials to access the bucket
-    - `region`: Region of the S3 bucket
+The secret must contain 3 fields:
 
-    For details, please check: [HyperShift Project Documentation](https://hypershift-docs.netlify.app/getting-started). For convenience, you can create this secret using the CLI by:
+- `aws-access-key-id`: AWS credential access key id
+- `aws-secret-access-key`: AWS credential access key secret
+- `region`: Region for use with Private Link
 
-    ```bash
-    $ oc create secret generic hypershift-operator-oidc-provider-s3-credentials --from-file=credentials=$HOME/.aws/credentials --from-literal=bucket=<s3-bucket-for-hypershift> --from-literal=region=<region> -n <managed-cluster-used-as-hosting-service-cluster>
-    ```
+See [HyperShift Project Documentation](https://hypershift-docs.netlify.app/how-to/aws/deploy-aws-private-clusters/) for details. For convenience, you can create this secret using the CLI by:
 
-    Add the special label to the `hypershift-operator-oidc-provider-s3-credentials` secret so that the secret is backed up for disaster recovery.
+```bash
+$ oc create secret generic hypershift-operator-private-link-credentials --from-literal=aws-access-key-id=<aws-access-key-id> --from-literal=aws-secret-access-key=<aws-secret-access-key> --from-literal=region=<region> -n <managed-cluster-used-as-hosting-service-cluster>
+```
 
-    ```bash
-    $ oc label secret hypershift-operator-oidc-provider-s3-credentials -n <managed-cluster-used-as-hosting-service-cluster> cluster.open-cluster-management.io/backup=true
-    ```
+**Note:** Disaster recovery backup for the secret is not automatically enabled. Run the following command to add the label that enables the `hypershift-operator-private-link-credentials` secret to be backed up for disaster recovery: 
 
-    ### AWS Private Link
-    If you plan to provision hosted clusters on the AWS platform with Private Link, create an AWS credential secret for the HyperShift operator, and name it `hypershift-operator-private-link-credentials`. It should reside in the managed cluster namespace (i.e., the namespace of the managed cluster that will be used as the hosting service cluster). If you used `local-cluster`, then create the secret in the `local-cluster` namespace
+```bash
+$ oc label secret hypershift-operator-private-link-credentials -n <managed-cluster-used-as-hosting-service-cluster> cluster.open-cluster-management.io/backup=true
+```
+**Enable on a HostedCluster**
 
-    Follow the instructions here (steps 1-5): [Deploy AWS private clusters](https://hypershift-docs.netlify.app/how-to/aws/deploy-aws-private-clusters/)
+Set the following parameter in HypershiftDeployment, when creating a cluster:
+```
+spec:
+  hostedClusterSpec:
+    platform:
+      type: AWS
+      aws:
+        endpointAccess: Private
+```
 
-    Instructions result in the following AWS resources:
+#### Enabling External DNS
+If you plan to use service-level DNS for Control Plane Service, create an external DNS credential secret for the HyperShift operator, and name it `hypershift-operator-external-dns-credentials`. It should reside in the managed cluster namespace (i.e., the namespace of the managed cluster that will be used as the hosting service cluster). If you used `local-cluster`, then create the secret in the `local-cluster` namespace
 
-    * Create an IAM policy in AWS
-    * Create an IAM user for the Hypershift operator to use
-    * Attach the IAM policy to the IAM user
-    * Create an IAM access key for the user, use the access key and secret in the next section
+The secret must contain 3 fields:
 
-    The secret must contain 3 fields:
+- `provider`: DNS provider that manages the service-level DNS zone (example: aws)
+- `domain-filter`: The service-level domain
+- `credentials`: *(Optional, only when using aws keys) - For all external DNS types, a credential file is supported
+- `aws-access-key-id`: *OPTIONAL* - When using AWS DNS service, credential access key id
+- `aws-secret-access-key`: *OPTIONAL* - When using AWS DNS service, credential access key secret
+For details, please check: [HyperShift Project Documentation](https://hypershift-docs.netlify.app/how-to/external-dns/). For convenience, you can create this secret using the CLI by:
 
-    - `aws-access-key-id`: AWS credential access key id
-    - `aws-secret-access-key`: AWS credential access key secret
-    - `region`: Region for use with Private Link
+```bash
+$ oc create secret generic hypershift-operator-external-dns-credentials --from-literal=provider=aws --from-literal=domain-filter=service.my.domain.com --from-file=credentials=<credentials-file> -n <managed-cluster-used-as-hosting-service-cluster>
+```
 
-    For details, please check: [HyperShift Project Documentation](https://hypershift-docs.netlify.app/how-to/aws/deploy-aws-private-clusters/). For convenience, you can create this secret using the CLI by:
+Add the special label to the `hypershift-operator-external-dns-credentials` secret so that the secret is backed up for disaster recovery.
 
-    ```bash
-    $ oc create secret generic hypershift-operator-private-link-credentials --from-literal=aws-access-key-id=<aws-access-key-id> --from-literal=aws-secret-access-key=<aws-secret-access-key> --from-literal=region=<region> -n <managed-cluster-used-as-hosting-service-cluster>
-    ```
+```bash
+$ oc label secret hypershift-operator-external-dns-credentials -n <managed-cluster-used-as-hosting-service-cluster> cluster.open-cluster-management.io/backup=true
+```
 
-    Add the special label to the `hypershift-operator-private-link-credentials` secret so that the secret is backed up for disaster recovery.
+**Enable on a HostedCluster**
 
-    ```bash
-    $ oc label secret hypershift-operator-private-link-credentials -n <managed-cluster-used-as-hosting-service-cluster> cluster.open-cluster-management.io/backup=true
-    ```
-    **Enable on a HostedCluster**
+Set the following parameter in HypershiftDeployment, when creating a cluster:
+```
+spec:
+  hostedClusterSpec:
+    platform:
+      type: AWS
+      aws:
+        endpointAccess: PublicAndPrivate
+...
+    services:
+    - service: APIServer
+      servicePublishingStrategy:
+        loadBalancer:
+          hostname: api-example.service.my.domain.com
+        type: LoadBalancer
+    - service: OAuthServer
+      servicePublishingStrategy:
+        route:
+          hostname: oauth-example.service.my.domain.com
+        type: Route
+    - service: Konnectivity
+      servicePublishingStrategy:
+        type: Route
+    - service: Ignition
+      servicePublishingStrategy:
+        type: Route        
 
-    Set the following parameter in HypershiftDeployment, when creating a cluster:
-    ```
-    spec:
-      hostedClusterSpec:
-        platform:
-          type: AWS
-          aws:
-            endpointAccess: Private
-    ```
+```
 
-    ### External DNS
-    If you plan to use service-level DNS for Control Plane Service, create an external DNS credential secret for the HyperShift operator, and name it `hypershift-operator-external-dns-credentials`. It should reside in the managed cluster namespace (i.e., the namespace of the managed cluster that will be used as the hosting service cluster). If you used `local-cluster`, then create the secret in the `local-cluster` namespace
-
-    The secret must contain 3 fields:
-
-    - `provider`: DNS provider that manages the service-level DNS zone (example: aws)
-    - `domain-filter`: The service-level domain
-    - `credentials`: *(Optional, only when using aws keys) - For all external DNS types, a credential file is supported
-    - `aws-access-key-id`: *OPTIONAL* - When using AWS DNS service, credential access key id
-    - `aws-secret-access-key`: *OPTIONAL* - When using AWS DNS service, credential access key secret
-    For details, please check: [HyperShift Project Documentation](https://hypershift-docs.netlify.app/how-to/external-dns/). For convenience, you can create this secret using the CLI by:
-
-    ```bash
-    $ oc create secret generic hypershift-operator-external-dns-credentials --from-literal=provider=aws --from-literal=domain-filter=service.my.domain.com --from-file=credentials=<credentials-file> -n <managed-cluster-used-as-hosting-service-cluster>
-    ```
-
-    Add the special label to the `hypershift-operator-external-dns-credentials` secret so that the secret is backed up for disaster recovery.
-
-    ```bash
-    $ oc label secret hypershift-operator-external-dns-credentials -n <managed-cluster-used-as-hosting-service-cluster> cluster.open-cluster-management.io/backup=true
-    ```
-    
-    **Enable on a HostedCluster**
-    
-    Set the following parameter in HypershiftDeployment, when creating a cluster:
-    ```
-    spec:
-      hostedClusterSpec:
-        platform:
-          type: AWS
-          aws:
-            endpointAccess: PublicAndPrivate
-    ...
-        services:
-        - service: APIServer
-          servicePublishingStrategy:
-            loadBalancer:
-              hostname: api-example.service.my.domain.com
-            type: LoadBalancer
-        - service: OAuthServer
-          servicePublishingStrategy:
-            route:
-              hostname: oauth-example.service.my.domain.com
-            type: Route
-        - service: Konnectivity
-          servicePublishingStrategy:
-            type: Route
-        - service: Ignition
-          servicePublishingStrategy:
-            type: Route        
-    
-    ```
-        
-2. Create `ManagedClusterAddon` hypershift-addon
+2. Install the HyperShift add-on. The cluster that hosts the HyperShift operator is the management cluster. This step uses the hypershift-addon to install the HyperShift operator on a managed cluster. `ManagedClusterAddon` hypershift-addon. Replace `managed-cluster-used-as-hosting-service-cluster` with the name of the managed cluster on which you want to install the HyperShift operator. If you are installing on the MCE hub cluster, then use `local-cluster` for this value.
   
-    ```bash
-    $ oc apply -f - <<EOF
-    apiVersion: addon.open-cluster-management.io/v1alpha1
-    kind: ManagedClusterAddOn
-    metadata:
-      name: hypershift-addon
-      namespace: <managed-cluster-used-as-hosting-service-cluster> # the managed OCP cluster you want to install hypershift operator
-    spec:
-      installNamespace: open-cluster-management-agent-addon
-    EOF
-    ```
+```bash
+$ oc apply -f - <<EOF
+apiVersion: addon.open-cluster-management.io/v1alpha1
+kind: ManagedClusterAddOn
+metadata:
+  name: hypershift-addon
+  namespace: <managed-cluster-used-as-hosting-service-cluster> # the managed OCP cluster you want to install hypershift operator
+spec:
+  installNamespace: open-cluster-management-agent-addon
+EOF
+```
 
-3. Check the `hypershift-addon` is installed
-      
-    ```bash
-    $ oc get managedclusteraddons -n local-cluster hypershift-addon
-    NAME               AVAILABLE   DEGRADED   PROGRESSING
-    hypershift-addon   True
-    ```
+3. Confirm that the `hypershift-addon` is installed by running the following command:
+  
+```bash
+$ oc get managedclusteraddons -n <managed-cluster-used-as-hosting-service-cluster> hypershift-addon
+NAME               AVAILABLE   DEGRADED   PROGRESSING
+hypershift-addon   True
+```
+
+Your HyperShift add-on is installed and the management cluster is available to manage HyperShift hosted clusters.
 
 ## Provision a HyperShift hosted cluster on AWS
 
-After the HyperShift operator is installed, we can provision a hypershift hosted cluster via the `HypershiftDeployment` customer resource.
+After installing the HyperShift operator and enabling an existing cluster as a hosting service cluster, you can provision a hypershift hosted cluster via the `HypershiftDeployment` customer resource.
 
-1. Create a cloud provider secret, it has the following format for AWS:
+1. Create a cloud provider secret as a credential using the console or a file addition. You must have permissions to create infrastructure resources for your cluster, like VPCs, subnets, and NAT gateways. The account also must correspond to the account for your guest cluster, where your workers live. See [Create AWS infrastructure and IAM resources separately](https://hypershift-docs.netlify.app/how-to/aws/create-infra-iam-separately) in the HyperShift documentation for more information about the required permissions. The secret has the following format for AWS:
 
-    ```yaml
-    apiVersion: v1
-    metadata:
-      name: my-aws-cred
-      namespace: <hypershift-deployment-ns>      # Where you will create HypershiftDeployment resources
-    type: Opaque
-    kind: Secret
-    stringData:
-      ssh-publickey:          # Value
-      ssh-privatekey:         # Value
-      pullSecret:             # Value, required
-      baseDomain:             # Value, required
-      aws_secret_access_key:  # Value, required
-      aws_access_key_id:      # Value, required
-    ```
+```yaml
+apiVersion: v1
+metadata:
+  name: my-aws-cred
+  namespace: <hypershift-deployment-ns>      # Where you will create HypershiftDeployment resources
+type: Opaque
+kind: Secret
+stringData:
+  ssh-publickey:          # Value
+  ssh-privatekey:         # Value
+  pullSecret:             # Value, required
+  baseDomain:             # Value, required
+  aws_secret_access_key:  # Value, required
+  aws_access_key_id:      # Value, required
+```
 
-    The `ssh-publickey` and `ssh-privatekey`, if provided, are used to access the worker nodes of the hosted cluster. If the SSH Key is provided in the `hostedCluster.spec.sshKey` or `hypershiftDeployment.spec.hostedClusterSpec.sshKey`, it takes precedence over the SSH Key provided in the cloud provider secret.
+The `ssh-publickey` and `ssh-privatekey`, if provided, are used to access the worker nodes of the hosted cluster. If the SSH Key is provided in the `hostedCluster.spec.sshKey` or `hypershiftDeployment.spec.hostedClusterSpec.sshKey`, it takes precedence over the SSH Key provided in the cloud provider secret.
 
-    You can create the cloud provider secret using the multicluster console (embedded within the OpenShift console) or via the CLI, both options are shown below:
+- To create this secret with the console, follow the credential creation steps by accessing *Credentials* in the navigation menu in MCE console: `https://<mce-multicluster-console>/multicloud/credentials/create`
+  
+![mce-console](./images/mce-console.png)  
 
-    - Multi-cluster console: `https://<mce-multicluster-console>/multicloud/credentials/create`
-      
-    ![mce-console](./images/mce-console.png)  
+- Using the CLI:
 
-    - Using the CLI:
+> The secret should be created where the HyperShift deployment controller is deployed. By default, it is deployed in the  `multicluster-engine` namespace.
 
-    > The secret should be created where the HyperShift deployment controller is deployed. By default, it is deployed in the  `multicluster-engine` namespace.
+```bash
+$ oc create secret generic <my-secret> -n <hypershift-deployment-namespace> --from-literal=baseDomain='your.domain.com' --from-literal=aws_access_key_id='your-aws-access-key' --from-literal=aws_secret_access_key='your-aws-secret-key' --from-literal=pullSecret='{"auths":{"cloud.openshift.com":{"auth":"auth-info", "email":"xx@redhat.com"}, "quay.io":{"auth":"auth-info", "email":"xx@redhat.com"} } }' --from-literal=ssh-publickey='your-ssh-publickey' --from-literal=ssh-privatekey='your-ssh-privatekey'
 
-    ```bash
-    $ oc create secret generic <my-secret> -n <hypershift-deployment-namespace> --from-literal=baseDomain='your.domain.com' --from-literal=aws_access_key_id='your-aws-access-key' --from-literal=aws_secret_access_key='your-aws-secret-key' --from-literal=pullSecret='{"auths":{"cloud.openshift.com":{"auth":"auth-info", "email":"xx@redhat.com"}, "quay.io":{"auth":"auth-info", "email":"xx@redhat.com"} } }' --from-literal=ssh-publickey='your-ssh-publickey' --from-literal=ssh-privatekey='your-ssh-privatekey'
+# label the secret for backup
+$ oc label secret <my-secret> -n <hypershift-deployment-namespace> cluster.open-cluster-management.io/backup=true
+```
 
-    # label the secret for backup
-    $ oc label secret <my-secret> -n <hypershift-deployment-namespace> cluster.open-cluster-management.io/backup=true
-    ```
+Note: `cluster.open-cluster-management.io/backup=true` is added to the secret so that the secret is backed up for disaster recovery.
 
-    Note: `cluster.open-cluster-management.io/backup=true` is added to the secret so that the secret is backed up for disaster recovery.
+1. Create a `HypershiftDeployment` custom resource. The `HypershiftDeployment` custom resource creates the infrastructure in the provider account, configures the infrastructure compute capacity in the created infrastructure, provisions the `nodePools` that use the hosted control plane, and creates a hosted control plane on a hosting service cluster. 
 
-1. Create a `HypershiftDeployment` in the cloud provider secret namespace
+```bash
+$ oc apply -f - <<EOF
+apiVersion: cluster.open-cluster-management.io/v1alpha1
+kind: HypershiftDeployment
+metadata:
+  name: <cluster>
+  namespace: default
+spec:
+  hostingCluster: <hypershift-management-cluster>
+  hostingNamespace: clusters
+  infrastructure:
+    cloudProvider:
+      name: <my-secret>
+    configure: True
+    platform:
+      aws:
+        region: <region>
+EOF
+```
 
-    ```bash
-    $ oc apply -f - <<EOF
-    apiVersion: cluster.open-cluster-management.io/v1alpha1
-    kind: HypershiftDeployment
-    metadata:
-      name: hypershift-demo
-      namespace: default
-    spec:
-      hostingCluster: hypershift-management-cluster     # the hypershift management cluster name.
-      hostingNamespace: clusters     # specify the namespace to which hostedcluster and noodpools belong on the hypershift management cluster.
-      infrastructure:
-        cloudProvider:
-          name: <my-secret>
-        configure: True
-        platform:
-          aws:
-            region: <region>
-            zones:
-            - <availability-zone-1>
-            - <availability-zone-2>
-    EOF
-    ```
+Replace `cluster` with the name of the cluster. 
 
-    Check each field [definition](./../api/v1alpha1/hypershiftdeployment_types.go)
+Replace `hypershift-management-cluster` with the name of the cluster that hosts the HyperShift operator. 
+
+Replace `my-secret` with the secret to access your cloud provider. 
+
+Replace `region` with the region of your cloud provider.
+
+Check each field [definition](./../api/v1alpha1/hypershiftdeployment_types.go)
 
 1. Check the `HypershiftDeployment` status:
 
-    ```bash
-    $ oc get hypershiftdeployment -n <hypershift-deployment-namespace> -w
-    ```
+```bash
+$ oc get hypershiftdeployment -n <hypershift-deployment-namespace> -w
+```
 
-    1. After the hosted cluster is created, it will be imported to the hub automatically, you can check it with:
-      
-    ```bash
-    $ oc get managedcluster <hypershiftDeployment.Spec.infraID>
-    ```
+1. After the hosted cluster is created, it will be imported to the hub automatically, you can check it with:
+  
+```bash
+$ oc get managedcluster <hypershiftDeployment.Spec.infraID>
+```
+
+## Access the hosted cluster
+
+The access secrets are stored in the {hypershift-management-cluster} namespace.
+The formats of the secrets name are:
+
+- kubeconfig secret: `<hypershiftDeployment.Spec.hostingNamespace>-<hypershiftDeployment.Name>-admin-kubeconfig` (e.g clusters-hypershift-demo-admin-kubeconfig)
+- kubeadmin password secret: `<hypershiftDeployment.Spec.hostingNamespace>-<hypershiftDeployment.Name>-kubeadmin-password` (e.g clusters-hypershift-demo-kubeadmin-password)
+
+## Destroying your hypershift Hosted cluster
+
+Delete the HypershiftDeployment resource
+
+```bash
+$ oc delete hypershiftdeployment hypershift-demo -n default
+```
+
+## Destroying hypershift operator
+
+Delete the hypershift-addon
+
+```bash
+$ oc delete managedclusteraddon -n <hypershift-management-cluster> hypershift-addon
+```
 
 ## Provision a hypershift hosted cluster on bare-metal
 
@@ -309,28 +342,3 @@ rules:
   - '*'
 EOF
 ~~~
-
-
-## Access the hosted cluster
-
-The access secrets are stored in the {hypershift-management-cluster} namespace.
-The formats of the secrets name are:
-
-- kubeconfig secret: `<hypershiftDeployment.Spec.hostingNamespace>-<hypershiftDeployment.Name>-admin-kubeconfig` (e.g clusters-hypershift-demo-admin-kubeconfig)
-- kubeadmin password secret: `<hypershiftDeployment.Spec.hostingNamespace>-<hypershiftDeployment.Name>-kubeadmin-password` (e.g clusters-hypershift-demo-kubeadmin-password)
-
-## Destroying your hypershift Hosted cluster
-
-Delete the HypershiftDeployment resource
-
-```bash
-$ oc delete hypershiftdeployment hypershift-demo -n default
-```
-
-## Destroying hypershift operator
-
-Delete the hypershift-addon
-
-```bash
-$ oc delete managedclusteraddon -n <hypershift-management-cluster> hypershift-addon
-```

--- a/pkg/constant/constants.go
+++ b/pkg/constant/constants.go
@@ -9,7 +9,7 @@ const (
 
 	ManagedClusterCleanupFinalizer = "hypershiftdeployment.cluster.open-cluster-management.io/managedcluster-cleanup"
 
-	ReleaseImage = "quay.io/openshift-release-dev/ocp-release:4.10.15-x86_64"
+	ReleaseImage = "quay.io/openshift-release-dev/ocp-release:4.11.2-x86_64"
 
 	// DestroyFinalizer makes sure infrastructure is cleaned up before it is removed
 	DestroyFinalizer = "hypershiftdeployment.cluster.open-cluster-management.io/finalizer"

--- a/pkg/controllers/default_resources.go
+++ b/pkg/controllers/default_resources.go
@@ -27,7 +27,6 @@ import (
 	hyp "github.com/openshift/hypershift/api/v1alpha1"
 	"github.com/openshift/hypershift/cmd/infra/aws"
 	"github.com/openshift/hypershift/cmd/infra/azure"
-	"github.com/openshift/hypershift/cmd/version"
 	hypdeployment "github.com/stolostron/hypershift-deployment-controller/api/v1alpha1"
 	"github.com/stolostron/hypershift-deployment-controller/pkg/constant"
 	"github.com/stolostron/hypershift-deployment-controller/pkg/helper"
@@ -46,11 +45,11 @@ var resLog = ctrl.Log.WithName("resource-render")
 
 func getReleaseImagePullSpec() string {
 
-	defaultVersion, err := version.LookupDefaultOCPVersion()
-	if err != nil {
-		return constant.ReleaseImage
-	}
-	return defaultVersion.PullSpec
+	//defaultVersion, err := version.LookupDefaultOCPVersion()
+	//if err != nil {
+	return constant.ReleaseImage
+	//}
+	//return defaultVersion.PullSpec
 }
 
 func (r *HypershiftDeploymentReconciler) scaffoldHostedCluster(ctx context.Context, hyd *hypdeployment.HypershiftDeployment) (*unstructured.Unstructured, error) {


### PR DESCRIPTION
<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* Currently, the OCP release image that is used for provisioning a new hypershift deployment does a live lookup of a latest stable OCP 4.x release image. This means after MCE 2.1 GA, a new hypershift hosted cluster might pick up OCP 4.12 release image that we have not tested with and break. We had this problem when we GA'd MCE 2.0 so we want to prevent this from happening after MCE 2.1 GA.

So we want to set the default image to quay.io/openshift-release-dev/ocp-release:4.11.2-x86_64 that we know and tested.

* I also made some changes in the doc to be more in sync with MCE doc because when people read both docs, they get confused which one is more accurate since they are somewhat different.

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://github.com/stolostron/backlog/issues/25343

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant -->
## Test API/Unit - Success
```script
oc get hostedcluster -A
NAMESPACE   NAME       VERSION   KUBECONFIG                  PROGRESS    AVAILABLE   PROGRESSING   MESSAGE
clusters    rj-0825a   4.11.2    rj-0825a-admin-kubeconfig   Completed   True        False         The hosted control plane is available

oc get hd              
NAME       TYPE   INFRA                  IAM                    MANIFESTWORK           PROVIDER REF   PROGRESS    AVAILABLE
rj-0825a   AWS    ConfiguredAsExpected   ConfiguredAsExpected   ConfiguredAsExpected   AsExpected     Completed   True

```

```script
  nodePools:
  - name: rj-0825a
    spec:
      clusterName: rj-0825a
      management:
        autoRepair: false
        replace:
          rollingUpdate:
            maxSurge: 1
            maxUnavailable: 0
          strategy: RollingUpdate
        upgradeType: Replace
      platform:
        aws:
          instanceProfile: rj-0825a-pgb6q-worker
          instanceType: t3.large
          rootVolume:
            size: 35
            type: gp3
          securityGroups:
          - id: sg-08ae910777d9bd59f
          subnet:
            id: subnet-013b0552a2c63968a
        type: AWS
      release:
        image: quay.io/openshift-release-dev/ocp-release:4.11.2-x86_64
      replicas: 2
```

```script
  hostedClusterSpec:
    autoscaling: {}
    clusterID: 1f90e076-dba8-42fe-bbac-7776752f22d5
    controllerAvailabilityPolicy: SingleReplica
    dns:
      baseDomain: dev06.red-chesterfield.com
      privateZoneID: Z0912479JI6IS92GT46U
      publicZoneID: Z2KFHRPLWG1H9H
    etcd:
      managed:
        storage:
          persistentVolume:
            size: 4Gi
          type: PersistentVolume
      managementType: Managed
    fips: false
    infraID: rj-0825a-pgb6q
    infrastructureAvailabilityPolicy: SingleReplica
    issuerURL: https://rj-aws-hyper.s3.us-east-1.amazonaws.com/rj-0825a-pgb6q
    networking:
      machineCIDR: 10.0.0.0/16
      networkType: OVNKubernetes
      podCIDR: 10.132.0.0/14
      serviceCIDR: 172.31.0.0/16
    olmCatalogPlacement: management
    platform:
      aws:
        cloudProviderConfig:
          subnet:
            id: subnet-013b0552a2c63968a
          vpc: vpc-09c56a0411abce004
          zone: us-east-1a
        controlPlaneOperatorCreds: {}
        endpointAccess: Public
        kubeCloudControllerCreds: {}
        nodePoolManagementCreds: {}
        region: us-east-1
        resourceTags:
        - key: kubernetes.io/cluster/rj-0825a-pgb6q
          value: owned
        rolesRef:
          controlPlaneOperatorARN: arn:aws:iam::845690120477:role/rj-0825a-pgb6q-control-plane-operator
          imageRegistryARN: arn:aws:iam::845690120477:role/rj-0825a-pgb6q-openshift-image-registry
          ingressARN: arn:aws:iam::845690120477:role/rj-0825a-pgb6q-openshift-ingress
          kubeCloudControllerARN: arn:aws:iam::845690120477:role/rj-0825a-pgb6q-cloud-controller
          networkARN: arn:aws:iam::845690120477:role/rj-0825a-pgb6q-cloud-network-config-controller
          nodePoolManagementARN: arn:aws:iam::845690120477:role/rj-0825a-pgb6q-node-pool
          storageARN: arn:aws:iam::845690120477:role/rj-0825a-pgb6q-aws-ebs-csi-driver-controller
      type: AWS
    pullSecret:
      name: rj-0825a-pull-secret
    release:
      image: quay.io/openshift-release-dev/ocp-release:4.11.2-x86_64
    secretEncryption:
      aescbc:
        activeKey:
          name: rj-0825a-etcd-encryption-key
      type: aescbc
    services:
    - service: APIServer
      servicePublishingStrategy:
        type: LoadBalancer
    - service: OAuthServer
      servicePublishingStrategy:
        type: Route
    - service: Konnectivity
      servicePublishingStrategy:
        type: Route
    - service: Ignition
      servicePublishingStrategy:
        type: Route
    sshKey: {}
```


