### PR TITLE
fixing manifestwork document

### DIFF
--- a/docs/provision_hypershift_clusters_by_manifestwork.md
+++ b/docs/provision_hypershift_clusters_by_manifestwork.md
@@ -23,7 +23,13 @@ metadata:
   namespace: my-hosting-cluster
 spec:
   deleteOption:
-    propagationPolicy: Orphan
+    propagationPolicy: SelectivelyOrphan
+    selectivelyOrphans:
+      orphaningRules:
+      - group: ""
+        name: clusters
+        namespace: ""
+        resource: namespaces
   manifestConfigs:
   - feedbackRules:
     - jsonPaths:

--- a/docs/provision_hypershift_clusters_by_mce.md
+++ b/docs/provision_hypershift_clusters_by_mce.md
@@ -112,6 +112,7 @@ The secret must contain 3 fields:
 - `credentials`: *(Optional, only when using aws keys) - For all external DNS types, a credential file is supported
 - `aws-access-key-id`: *OPTIONAL* - When using AWS DNS service, credential access key id
 - `aws-secret-access-key`: *OPTIONAL* - When using AWS DNS service, credential access key secret
+
 For details, please check: [HyperShift Project Documentation](https://hypershift-docs.netlify.app/how-to/external-dns/). For convenience, you can create this secret using the CLI by:
 
 ```bash


### PR DESCRIPTION
Signed-off-by: Roke Jung <roke@redhat.com>

<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* The `deleteOption` in the documentation on using Manifestwork to create a hosted cluster needs to be fixed so that deleting Manifestwork deletes all resources it creates.

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-1610

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant -->
## Test API/Unit - Success
```script

```

